### PR TITLE
検索機能の実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,5 +37,6 @@
 
 /memo.md
 /.env
+/.env.production
 /config/credentials
 /config/credentials.yml.enc

--- a/Gemfile
+++ b/Gemfile
@@ -84,3 +84,5 @@ end
 gem "dotenv-rails"
 
 gem "sorcery"
+
+gem "ransack"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -229,6 +229,10 @@ GEM
       zeitwerk (~> 2.5)
     rainbow (3.1.1)
     rake (13.2.1)
+    ransack (4.2.1)
+      activerecord (>= 6.1.5)
+      activesupport (>= 6.1.5)
+      i18n
     rbs (2.8.4)
     rdoc (6.7.0)
       psych (>= 4.0.0)
@@ -332,6 +336,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 5.0)
   rails (~> 7.0.8, >= 7.0.8.4)
+  ransack
   selenium-webdriver
   solargraph
   sorcery

--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -96,6 +96,17 @@ footer {
     align-items: center;
 }
 
+.normal-button {
+    margin-left: auto;
+    margin-right: auto;
+    height: 60px;
+    width: 30%;
+    background-color: #FF7171;
+    border-radius: 7px;
+    justify-content: center;
+    align-items: center;
+}
+
 .alert {
     border-radius: 0;
 }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,9 +1,15 @@
 class ApplicationController < ActionController::Base
+  before_action :set_search
+
   private
 
   def redirect_if_logged_in
     if logged_in?
       redirect_to root_path, notice: 'すでにログインしています。'
     end
+  end
+
+  def set_search
+    @q = SongPair.ransack(params[:q])
   end
 end

--- a/app/controllers/song_pairs_controller.rb
+++ b/app/controllers/song_pairs_controller.rb
@@ -2,9 +2,14 @@ class SongPairsController < ApplicationController
   before_action :require_login, only: [:create]
 
   def index
-    @song_pairs = SongPair.all.order(created_at: :desc)
+    @q = SongPair.ransack(params[:q])
+    @song_pairs = @q.result(distinct: true).includes(:original_song, :similar_song, :similarity_category, :original_song => :artists, :similar_song => :artists).order(created_at: :desc)
   end
   
+  def recent_page
+    @song_pairs = SongPair.includes(:original_song, :similar_song, :similarity_category, :original_song => :artists, :similar_song => :artists).all.order(created_at: :desc)
+  end
+
   def new
     @song_pair = SongPair.new
     @song_pair.build_original_song

--- a/app/models/song.rb
+++ b/app/models/song.rb
@@ -39,6 +39,24 @@ class Song < ApplicationRecord
     end
   end
 
+  def self.ransackable_attributes(auth_object = nil)
+    ["title", "artist_list"]
+  end
+
+  def self.ransackable_associations(auth_object = nil)
+    ["artists"]
+  end
+
+  ransacker :artist_list do
+    Arel.sql <<-SQL
+      (SELECT GROUP_CONCAT(artists.name SEPARATOR ', ')
+       FROM song_artists
+       JOIN artists ON song_artists.artist_id = artists.id
+       WHERE song_artists.song_id = songs.id
+       GROUP BY song_artists.song_id)
+    SQL
+  end
+
   private
 
   def release_date_check

--- a/app/models/song_pair.rb
+++ b/app/models/song_pair.rb
@@ -23,4 +23,12 @@ class SongPair < ApplicationRecord
     end
     return song
   end
+
+  def self.ransackable_attributes(auth_object = nil)
+    ["created_at", "original_song_id", "similar_song_id", "similarity_category_id"]
+  end
+
+  def self.ransackable_associations(auth_object = nil)
+    ["original_song", "similar_song", "similarity_category"]
+  end
 end

--- a/app/views/home/top.html.erb
+++ b/app/views/home/top.html.erb
@@ -16,7 +16,7 @@
       </div>
     <% end %>
     <div class="more-button d-flex justify-content-center">
-      <%= link_to "もっと見る", song_pairs_path, class: "btn" %>
+      <%= link_to "もっと見る", recent_path, class: "btn" %>
     </div>
   </div>
 </div>

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -25,6 +25,10 @@
       <div class="main-area d-flex flex-column align-items-center">
         <h1>『似ている』から始まる曲探し</h1>
         <%=link_to 'アカウント登録・ログインをして始める', signup_path %>
+        <%= search_form_for @q, url: song_pairs_path, method: :get, class: 'search-form' do |f| %>
+          <%= f.text_field :original_song_title_or_similar_song_title_or_original_song_artist_list_cont, placeholder: "曲名やアーティスト名を検索", class: "search-input" %>
+          <%= f.submit "検索", class: "search-submit" %>
+        <% end %>
       </div>
     </div>
   <% end %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -21,8 +21,9 @@
     <div class="header-image text-white">
       <div class="main-area d-flex flex-column align-items-center">
         <h1>『似ている』から始まる曲探し</h1>
-        <% unless logged_in? %>
-          <%=link_to 'アカウント登録・ログインをして始める', signup_path %>
+        <%= search_form_for @q, url: song_pairs_path, method: :get, class: 'search-form' do |f| %>
+          <%= f.text_field :original_song_title_or_similar_song_title_or_original_song_artist_list_cont, placeholder: "曲名やアーティスト名を検索", class: "search-input" %>
+          <%= f.submit "検索", class: "search-submit" %>
         <% end %>
       </div>
     </div>

--- a/app/views/song_pairs/index.html.erb
+++ b/app/views/song_pairs/index.html.erb
@@ -1,19 +1,34 @@
 <div>
-  <h1 class="text-center mb-4">最近登録された曲</h1>
+  <h1 class="text-center mb-4">検索結果</h1>
   <div class="mb-4">
-    <% @song_pairs.each do |song_pair| %>
-      <div class="song-block d-flex align-items-center mb-3">
-        <div class="song-jacket d-flex align-items-center justify-content-center flex-shrink-0 me-3">
-          jacket
-        </div>
-        <div class="song-title">
-          <h3 class="mb-1"><%= link_to "#{song_pair.original_song.artist_list} - #{song_pair.original_song.title}", song_pair, class: "text-dark" %></h3>
-          <p class="mb-0">→似てる曲: <%= song_pair.similar_song.artist_list %> - <%= song_pair.similar_song.title %></p>
-        </div>
-        <div class="song-category ms-auto">
-          <%= link_to "カテゴリー: #{song_pair.similarity_category.name}", "#"%>
-        </div>
+    <% if @song_pairs.blank? %>
+      <div class="text-center mb-3">
+        <p>楽曲が見つかりませんでした。</p>
       </div>
+      <% if logged_in? %>
+        <div class="normal-button d-flex justify-content-center">
+          <%= link_to "楽曲を登録する", new_song_pair_path, class: "btn" %>
+        </div>
+      <% else %>
+        <div class="normal-button d-flex justify-content-center">
+          <%= link_to "アカウント登録・ログインをして楽曲を登録", login_path, class: "btn" %>
+        </div>
+      <% end %>
+    <% else %>
+      <% @song_pairs.each do |song_pair| %>
+        <div class="song-block d-flex align-items-center mb-3">
+          <div class="song-jacket d-flex align-items-center justify-content-center flex-shrink-0 me-3">
+            jacket
+          </div>
+          <div class="song-title">
+            <h3 class="mb-1"><%= link_to "#{song_pair.original_song.artist_list} - #{song_pair.original_song.title}", song_pair, class: "text-dark" %></h3>
+            <p class="mb-0">→似てる曲: <%= song_pair.similar_song.artist_list %> - <%= song_pair.similar_song.title %></p>
+          </div>
+          <div class="song-category ms-auto">
+            <%= link_to "カテゴリー: #{song_pair.similarity_category.name}", "#"%>
+          </div>
+        </div>
+      <% end %>
     <% end %>
   </div>
 </div>

--- a/app/views/song_pairs/recent_page.html.erb
+++ b/app/views/song_pairs/recent_page.html.erb
@@ -1,0 +1,19 @@
+<div>
+  <h1 class="text-center mb-4">最近登録された曲</h1>
+  <div class="mb-4">
+    <% @song_pairs.each do |song_pair| %>
+      <div class="song-block d-flex align-items-center mb-3">
+        <div class="song-jacket d-flex align-items-center justify-content-center flex-shrink-0 me-3">
+          jacket
+        </div>
+        <div class="song-title">
+          <h3 class="mb-1"><%= link_to "#{song_pair.original_song.artist_list} - #{song_pair.original_song.title}", song_pair, class: "text-dark" %></h3>
+          <p class="mb-0">→似てる曲: <%= song_pair.similar_song.artist_list %> - <%= song_pair.similar_song.title %></p>
+        </div>
+        <div class="song-category ms-auto">
+          <%= link_to "カテゴリー: #{song_pair.similarity_category.name}", "#"%>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
     end
   end
   resources :song_pairs, only: [:index, :new, :create, :show]
+  get 'recent', to: 'song_pairs#recent_page'
   resources :artists, only: [] do
     collection do
       get 'autocomplete'

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -21,6 +21,8 @@ services:
       - node_modules:/similar-songs/node_modules
     environment:
       TZ: Asia/Tokyo
+      RAILS_ENV: ${RAILS_ENV}
+      RAILS_SERVE_STATIC_FILES: ${RAILS_SERVE_STATIC_FILES}
     ports:
       - "127.0.0.1:3000:3000"
     depends_on:


### PR DESCRIPTION
# 概要
こちら https://github.com/8kjapon/similar-songs/issues/13 のissueに基づいて楽曲の検索機能を実装

# 詳細
- Gem "ransack"を用いた検索機能の実装
- 楽曲名・アーティスト名を含めたあいまい検索に対応
- 検索結果ページを`song_pairs_controller.rb`の`index`アクションを使用したことに伴い、`最近登録された曲`ページを`recent_page`アクションを介する仕様に変更