### PR TITLE
楽曲情報ページの各カテゴリーの曲一覧ページを作成

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 class ApplicationController < ActionController::Base
+  before_action :require_login
   before_action :set_search
 
   private

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,4 +1,6 @@
 class HomeController < ApplicationController
+  skip_before_action :require_login, only: %i[top]
+  
   def top
     @song_pairs = SongPair.all.order(created_at: :desc)
   end

--- a/app/controllers/song_pairs_controller.rb
+++ b/app/controllers/song_pairs_controller.rb
@@ -1,5 +1,5 @@
 class SongPairsController < ApplicationController
-  before_action :require_login, only: [:create]
+  skip_before_action :require_login, only: %i[index show]
 
   def index
     @q = SongPair.ransack(params[:q])

--- a/app/controllers/songs_controller.rb
+++ b/app/controllers/songs_controller.rb
@@ -1,6 +1,27 @@
 class SongsController < ApplicationController
   def show
-    @song = Song.find(params[:id])
+    @song = Song.includes(:artists, :song_pairs).find(params[:id])
+  end
+
+  def melody_song_pairs
+    @song = Song.includes(:artists, :song_pairs).find(params[:id])
+    unless @song.melody_pairs.count > 3
+      redirect_to song_path
+    end
+  end
+
+  def style_song_pairs
+    @song = Song.includes(:artists, :song_pairs).find(params[:id])
+    unless @song.style_pairs.count > 3
+      redirect_to song_path
+    end
+  end
+
+  def sampling_song_pairs
+    @song = Song.includes(:artists, :song_pairs).find(params[:id])
+    unless @song.sampling_pairs.count > 3
+      redirect_to song_path
+    end
   end
 
   def autocomplete

--- a/app/controllers/songs_controller.rb
+++ b/app/controllers/songs_controller.rb
@@ -1,4 +1,6 @@
 class SongsController < ApplicationController
+  skip_before_action :require_login, only: %i[show melody_song_pairs style_song_pairs sampling_song_pairs]
+
   def show
     @song = Song.includes(:artists, :song_pairs).find(params[:id])
   end

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -1,5 +1,5 @@
 class UserSessionsController < ApplicationController
-  # skip_before_action :require_login, only: %i[new create]
+  skip_before_action :require_login, only: %i[new create]
   before_action :redirect_if_logged_in, only: %i[new create]
 
   def new; end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,5 @@
 class UsersController < ApplicationController
-  # skip_before_action :require_login, only: %i[new create]
+  skip_before_action :require_login, only: %i[new create]
   before_action :redirect_if_logged_in, only: %i[new create]
 
   def new

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -25,9 +25,9 @@
       <div class="main-area d-flex flex-column align-items-center">
         <h1>『似ている』から始まる曲探し</h1>
         <%=link_to 'アカウント登録・ログインをして始める', signup_path %>
-        <%= search_form_for @q, url: song_pairs_path, method: :get, class: 'search-form' do |f| %>
-          <%= f.text_field :original_song_title_or_similar_song_title_or_original_song_artist_list_cont, placeholder: "曲名やアーティスト名を検索", class: "search-input" %>
-          <%= f.submit "検索", class: "search-submit" %>
+        <%= search_form_for @q, url: song_pairs_path, method: :get, class: 'd-flex input-group mb-3' do |f| %>
+          <%= f.text_field :original_song_title_or_similar_song_title_or_original_song_artist_list_cont, placeholder: "曲名やアーティスト名から検索", class: "form-control" %>
+          <%= f.submit "検索", class: "btn btn-primary" %>
         <% end %>
       </div>
     </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -21,9 +21,9 @@
     <div class="header-image text-white">
       <div class="main-area d-flex flex-column align-items-center">
         <h1>『似ている』から始まる曲探し</h1>
-        <%= search_form_for @q, url: song_pairs_path, method: :get, class: 'search-form' do |f| %>
-          <%= f.text_field :original_song_title_or_similar_song_title_or_original_song_artist_list_cont, placeholder: "曲名やアーティスト名を検索", class: "search-input" %>
-          <%= f.submit "検索", class: "search-submit" %>
+        <%= search_form_for @q, url: song_pairs_path, method: :get, class: 'd-flex input-group mb-3' do |f| %>
+          <%= f.text_field :original_song_title_or_similar_song_title_or_original_song_artist_list_cont, placeholder: "曲名やアーティスト名から検索", class: "form-control" %>
+          <%= f.submit "検索", class: "btn btn-primary" %>
         <% end %>
       </div>
     </div>

--- a/app/views/songs/melody_song_pairs.html.erb
+++ b/app/views/songs/melody_song_pairs.html.erb
@@ -1,0 +1,31 @@
+<h1 class="text-center mb-4">楽曲情報</h1>
+<div class="mb-4 song-info-block">
+  <h3><%= @song.title %></h3>
+  <p>アーティスト名: 
+    <% @song.artists.each do |artist| %>
+      <%= artist.name %>
+    <% end %>
+  </p>
+  <p>リリース年: <%= @song.release_date %></p>
+</div>
+<div>
+  <h4 class="text-center mb-4">この曲とメロディーが似てる曲</h4>
+  <div class="mb-4">
+    <% if @song.melody_pairs.present? %>
+      <% @song.melody_pairs.each do |song| %>
+        <div class="song-block d-flex align-items-center mb-3">
+            <div class="song-jacket d-flex align-items-center justify-content-center flex-shrink-0 me-3">
+              jacket
+            </div>
+            <div class="song-title">
+              <h3 class="mb-1"><%= link_to "#{song.artist_list} - #{song.title}", @song.song_pair(song), class: "text-dark" %></h3>
+            </div>
+          </div>
+      <% end %>
+    <% else %>
+      <div class="text-center">
+        <p>このカテゴリーの楽曲は登録されていません。</p>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/songs/sampling_song_pairs.html.erb
+++ b/app/views/songs/sampling_song_pairs.html.erb
@@ -1,0 +1,31 @@
+<h1 class="text-center mb-4">楽曲情報</h1>
+<div class="mb-4 song-info-block">
+  <h3><%= @song.title %></h3>
+  <p>アーティスト名: 
+    <% @song.artists.each do |artist| %>
+      <%= artist.name %>
+    <% end %>
+  </p>
+  <p>リリース年: <%= @song.release_date %></p>
+</div>
+<div>
+  <h4 class="text-center mb-4">この曲がサンプリングしてる・されてる曲</h4>
+  <div class="mb-4">
+    <% if @song.sampling_pairs.present? %>
+      <% @song.sampling_pairs.each do |song| %>
+        <div class="song-block d-flex align-items-center mb-3">
+            <div class="song-jacket d-flex align-items-center justify-content-center flex-shrink-0 me-3">
+              jacket
+            </div>
+            <div class="song-title">
+              <h3 class="mb-1"><%= link_to "#{song.artist_list} - #{song.title}", song, class: "text-dark" %></h3>
+            </div>
+          </div>
+      <% end %>
+    <% else %>
+      <div class="text-center">
+        <p>このカテゴリーの楽曲は登録されていません。</p>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/songs/show.html.erb
+++ b/app/views/songs/show.html.erb
@@ -12,8 +12,8 @@
 <div>
   <h4 class="text-center mb-4">この曲とメロディーが似てる曲</h4>
   <div class="mb-4">
-    <% if @song.pair_song_list(1).present? %>
-      <% @song.pair_song_list(1).each do |song| %>
+    <% if @song.melody_pairs.present? %>
+      <% @song.melody_pairs.take(3).each do |song| %>
         <div class="song-block d-flex align-items-center mb-3">
             <div class="song-jacket d-flex align-items-center justify-content-center flex-shrink-0 me-3">
               jacket
@@ -22,6 +22,11 @@
               <h3 class="mb-1"><%= link_to "#{song.artist_list} - #{song.title}", @song.song_pair(song), class: "text-dark" %></h3>
             </div>
           </div>
+      <% end %>
+      <% if @song.melody_pairs.count > 3 %>
+        <div class="more-button d-flex justify-content-center">
+          <%= link_to "全て表示", melody_song_path, class: "btn" %>
+        </div>
       <% end %>
     <% else %>
       <div class="text-center">
@@ -33,8 +38,8 @@
 <div>
   <h4 class="text-center mb-4">この曲とジャンル・スタイルが似てる曲</h4>
   <div class="mb-4">
-    <% if @song.pair_song_list(2).present? %>
-      <% @song.pair_song_list(2).each do |song| %>
+    <% if @song.style_pairs.present? %>
+      <% @song.style_pairs.take(3).each do |song| %>
         <div class="song-block d-flex align-items-center mb-3">
             <div class="song-jacket d-flex align-items-center justify-content-center flex-shrink-0 me-3">
               jacket
@@ -43,6 +48,11 @@
               <h3 class="mb-1"><%= link_to "#{song.artist_list} - #{song.title}", song, class: "text-dark" %></h3>
             </div>
           </div>
+      <% end %>
+      <% if @song.style_pairs.count > 3 %>
+        <div class="more-button d-flex justify-content-center">
+          <%= link_to "全て表示", style_song_path, class: "btn" %>
+        </div>
       <% end %>
     <% else %>
       <div class="text-center">
@@ -54,8 +64,8 @@
 <div>
   <h4 class="text-center mb-4">この曲がサンプリングしてる・されてる曲</h4>
   <div class="mb-4">
-    <% if @song.pair_song_list(3).present? %>
-      <% @song.pair_song_list(3).each do |song| %>
+    <% if @song.sampling_pairs.present? %>
+      <% @song.sampling_pairs.take(3).each do |song| %>
         <div class="song-block d-flex align-items-center mb-3">
             <div class="song-jacket d-flex align-items-center justify-content-center flex-shrink-0 me-3">
               jacket
@@ -64,6 +74,11 @@
               <h3 class="mb-1"><%= link_to "#{song.artist_list} - #{song.title}", song, class: "text-dark" %></h3>
             </div>
           </div>
+      <% end %>
+      <% if @song.sampling_pairs.count > 3 %>
+        <div class="more-button d-flex justify-content-center">
+          <%= link_to "全て表示", sampling_song_path, class: "btn" %>
+        </div>
       <% end %>
     <% else %>
       <div class="text-center">

--- a/app/views/songs/style_song_pairs.html.erb
+++ b/app/views/songs/style_song_pairs.html.erb
@@ -1,0 +1,31 @@
+<h1 class="text-center mb-4">楽曲情報</h1>
+<div class="mb-4 song-info-block">
+  <h3><%= @song.title %></h3>
+  <p>アーティスト名: 
+    <% @song.artists.each do |artist| %>
+      <%= artist.name %>
+    <% end %>
+  </p>
+  <p>リリース年: <%= @song.release_date %></p>
+</div>
+<div>
+  <h4 class="text-center mb-4">この曲とジャンル・スタイルが似てる曲</h4>
+  <div class="mb-4">
+    <% if @song.style_pairs.present? %>
+      <% @song.style_pairs.each do |song| %>
+        <div class="song-block d-flex align-items-center mb-3">
+            <div class="song-jacket d-flex align-items-center justify-content-center flex-shrink-0 me-3">
+              jacket
+            </div>
+            <div class="song-title">
+              <h3 class="mb-1"><%= link_to "#{song.artist_list} - #{song.title}", song, class: "text-dark" %></h3>
+            </div>
+          </div>
+      <% end %>
+    <% else %>
+      <div class="text-center">
+        <p>このカテゴリーの楽曲は登録されていません。</p>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,11 @@ Rails.application.routes.draw do
   delete 'logout', to: 'user_sessions#destroy'
 
   resources :songs, only: [:show] do
+    member do
+      get 'melody', to: 'songs#melody_song_pairs'
+      get 'style', to: 'songs#style_song_pairs'
+      get 'sampling', to: 'songs#sampling_song_pairs'
+    end
     collection do
       get 'autocomplete'
     end


### PR DESCRIPTION
# 概要
楽曲情報ページよりアクセスできる各カテゴリーの曲一覧を表示するための機能とページを実装

# 詳細
`root/songs/id`の楽曲情報ページ上で表示される各カテゴリーの曲一覧である以下の項目をそれぞれ専用の一覧ページに遷移できるように、機能とページを作成し、実装
- この曲とメロディーが似てる曲 (カテゴリー`melody`)
- この曲とジャンル・スタイルが似てる曲 (カテゴリー`style`)
- この曲がサンプリングしてる・されてる曲 (カテゴリー`sampling`)

該当するデータが3件より多くある場合は`全て表示`ボタンを表示し、3件までのデータを表示
データが3件以下の場合は3件までのデータを表示し、`全て表示`ボタンは表示しない
また、データが3件以下のカテゴリーの一覧ページにURLから直接アクセスしようとしても楽曲情報ページにリダイレクトするように設定

# その他調整点
- 検索フォームのUIの調整
- ログイン状況による各ページへのアクセス制限の調整