### PR TITLE
update: 一覧表示部分のリンク先修正

### DIFF
--- a/app/views/songs/show.html.erb
+++ b/app/views/songs/show.html.erb
@@ -45,7 +45,7 @@
               jacket
             </div>
             <div class="song-title">
-              <h3 class="mb-1"><%= link_to "#{song.artist_list} - #{song.title}", song, class: "text-dark" %></h3>
+              <h3 class="mb-1"><%= link_to "#{song.artist_list} - #{song.title}", @song.song_pair(song), class: "text-dark" %></h3>
             </div>
           </div>
       <% end %>
@@ -71,7 +71,7 @@
               jacket
             </div>
             <div class="song-title">
-              <h3 class="mb-1"><%= link_to "#{song.artist_list} - #{song.title}", song, class: "text-dark" %></h3>
+              <h3 class="mb-1"><%= link_to "#{song.artist_list} - #{song.title}", @song.song_pair(song), class: "text-dark" %></h3>
             </div>
           </div>
       <% end %>


### PR DESCRIPTION
# 概要
各カテゴリーの楽曲一覧項目のリンク先を修正

# 詳細
各カテゴリーの楽曲一覧項目のリンク先が楽曲情報ページになっていた部分を対応した似てる曲の組み合わせページにリンクするように修正