### PR TITLE
画面遷移の調整

### DIFF
--- a/app/views/songs/sampling_song_pairs.html.erb
+++ b/app/views/songs/sampling_song_pairs.html.erb
@@ -18,7 +18,7 @@
               jacket
             </div>
             <div class="song-title">
-              <h3 class="mb-1"><%= link_to "#{song.artist_list} - #{song.title}", song, class: "text-dark" %></h3>
+              <h3 class="mb-1"><%= link_to "#{song.artist_list} - #{song.title}", @song.song_pair(song), class: "text-dark" %></h3>
             </div>
           </div>
       <% end %>

--- a/app/views/songs/style_song_pairs.html.erb
+++ b/app/views/songs/style_song_pairs.html.erb
@@ -18,7 +18,7 @@
               jacket
             </div>
             <div class="song-title">
-              <h3 class="mb-1"><%= link_to "#{song.artist_list} - #{song.title}", song, class: "text-dark" %></h3>
+              <h3 class="mb-1"><%= link_to "#{song.artist_list} - #{song.title}", @song.song_pair(song), class: "text-dark" %></h3>
             </div>
           </div>
       <% end %>


### PR DESCRIPTION
# 概要
以下のプロジェクトのissueに基づいて画面遷移設定の確認と調整
- https://github.com/8kjapon/similar-songs/issues/21
- https://github.com/8kjapon/similar-songs/issues/22

# 詳細
似てる楽曲の組み合わせページや任意の曲と似ている曲一覧ページなどから似ている曲を選択した場合に移動するページを楽曲情報ページから楽曲の組み合わせページに遷移するように変更
その他各ページから楽曲情報ページや組み合わせページへの画面遷移が正常に行われるかを確認