### PR TITLE
Viewのテンプレート化

### DIFF
--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -50,7 +50,7 @@ footer {
     }
 }
 
-.song-block {
+.song-block,.song-pair-block {
     background-color: #fff;
     color: #000;
     height: 75px;

--- a/app/controllers/song_pairs_controller.rb
+++ b/app/controllers/song_pairs_controller.rb
@@ -58,7 +58,6 @@ class SongPairsController < ApplicationController
 
   def show
     @song_pair = SongPair.find(params[:id])
-    # ahoy.track_visit
   end
 
   private

--- a/app/controllers/songs_controller.rb
+++ b/app/controllers/songs_controller.rb
@@ -7,21 +7,21 @@ class SongsController < ApplicationController
 
   def melody_song_pairs
     @song = Song.includes(:artists, :song_pairs).find(params[:id])
-    unless @song.melody_pairs.count > 3
+    unless @song.pair_song_list(similarity_category: 'melody').count > 3
       redirect_to song_path
     end
   end
 
   def style_song_pairs
     @song = Song.includes(:artists, :song_pairs).find(params[:id])
-    unless @song.style_pairs.count > 3
+    unless @song.pair_song_list(similarity_category: 'style').count > 3
       redirect_to song_path
     end
   end
 
   def sampling_song_pairs
     @song = Song.includes(:artists, :song_pairs).find(params[:id])
-    unless @song.sampling_pairs.count > 3
+    unless @song.pair_song_list(similarity_category: 'sampling').count > 3
       redirect_to song_path
     end
   end

--- a/app/models/song.rb
+++ b/app/models/song.rb
@@ -14,19 +14,27 @@ class Song < ApplicationRecord
   def media_url_id
     extract_media_id(media_url)
   end
+  
+  def pair_song_list(similarity_category: nil)
+    similarity_category_id = case similarity_category
+                              when 'melody'
+                                1
+                              when 'style'
+                                2
+                              when 'sampling'
+                                3
+                              end
 
-  def melody_pairs
-    pair_song_list(1)
+    # 似てる曲(original側)として紐づけられてる曲一覧の取得
+    song_list = song_pairs.where(similarity_category_id: similarity_category_id).map(&:similar_song)
+    
+    # 似てる曲(similar側)として紐づけられてる曲一覧の取得
+    similar_song_list = similar_song_pairs.where(similarity_category_id: similarity_category_id).map(&:original_song)
+    
+    # 曲一覧の結合と登録日順でソート
+    song_list = song_list | similar_song_list
+    song_list.sort_by{ |song| -song.created_at.to_i }
   end
-
-  def style_pairs
-    pair_song_list(2)
-  end
-
-  def sampling_pairs
-    pair_song_list(3)
-  end
-
   
   def artist_list
     artists.map(&:name).join(', ')
@@ -75,15 +83,4 @@ class Song < ApplicationRecord
     match[2] if match && match[2].length == 11
   end
   
-  def pair_song_list(similarity_category_id)
-    # 似てる曲(original側)として紐づけられてる曲一覧の取得
-    song_list = song_pairs.where(similarity_category_id: similarity_category_id).map(&:similar_song)
-    
-    # 似てる曲(similar側)として紐づけられてる曲一覧の取得
-    similar_song_list = similar_song_pairs.where(similarity_category_id: similarity_category_id).map(&:original_song)
-    
-    # 曲一覧の結合と登録日順でソート
-    song_list = song_list | similar_song_list
-    song_list.sort_by{ |song| -song.created_at.to_i }
-  end
 end

--- a/app/models/song.rb
+++ b/app/models/song.rb
@@ -15,7 +15,7 @@ class Song < ApplicationRecord
     extract_media_id(media_url)
   end
   
-  def pair_song_list(similarity_category: nil)
+  def pair_song_list(similarity_category: nil, maximum: 0)
     similarity_category_id = case similarity_category
                               when 'melody'
                                 1
@@ -33,7 +33,11 @@ class Song < ApplicationRecord
     
     # 曲一覧の結合と登録日順でソート
     song_list = song_list | similar_song_list
-    song_list.sort_by{ |song| -song.created_at.to_i }
+    if maximum > 0
+      song_list.sort_by{ |song| -song.created_at.to_i }.take(maximum)
+    else
+      song_list.sort_by{ |song| -song.created_at.to_i }
+    end
   end
   
   def artist_list

--- a/app/views/home/top.html.erb
+++ b/app/views/home/top.html.erb
@@ -1,7 +1,7 @@
 <div>
   <h1 class="text-center mb-4">最近登録された曲</h1>
   <div class="mb-4">
-    <%= render "shared/song_block", song_pairs: @song_pairs %>
+    <%= render "shared/song_pair_block", song_pairs: @song_pairs %>
     <div class="more-button d-flex justify-content-center">
       <%= link_to "もっと見る", recent_path, class: "btn" %>
     </div>

--- a/app/views/home/top.html.erb
+++ b/app/views/home/top.html.erb
@@ -1,20 +1,7 @@
 <div>
   <h1 class="text-center mb-4">最近登録された曲</h1>
   <div class="mb-4">
-    <% @song_pairs.each do |song_pair| %>
-      <div class="song-block d-flex align-items-center mb-3">
-        <div class="song-jacket d-flex align-items-center justify-content-center flex-shrink-0 me-3">
-          jacket
-        </div>
-        <div class="song-title">
-          <h3 class="mb-1"><%= link_to "#{song_pair.original_song.artist_list} - #{song_pair.original_song.title}", song_pair, class: "text-dark" %></h3>
-          <p class="mb-0">→似てる曲: <%= song_pair.similar_song.artist_list %> - <%= song_pair.similar_song.title %></p>
-        </div>
-        <div class="song-category ms-auto">
-          <%= link_to "カテゴリー: #{song_pair.similarity_category.name}", "#"%>
-        </div>
-      </div>
-    <% end %>
+    <%= render "shared/song_block", song_pairs: @song_pairs %>
     <div class="more-button d-flex justify-content-center">
       <%= link_to "もっと見る", recent_path, class: "btn" %>
     </div>

--- a/app/views/shared/_song_block.html.erb
+++ b/app/views/shared/_song_block.html.erb
@@ -1,14 +1,8 @@
-<% song_pairs.each do |song_pair| %>
-  <div class="song-block d-flex align-items-center mb-3">
-    <div class="song-jacket d-flex align-items-center justify-content-center flex-shrink-0 me-3">
-      jacket
-    </div>
-    <div class="song-title">
-      <h3 class="mb-1"><%= link_to "#{song_pair.original_song.artist_list} - #{song_pair.original_song.title}", song_pair, class: "text-dark" %></h3>
-      <p class="mb-0">→似てる曲: <%= song_pair.similar_song.artist_list %> - <%= song_pair.similar_song.title %></p>
-    </div>
-    <div class="song-category ms-auto">
-      <%= link_to "カテゴリー: #{song_pair.similarity_category.name}", "#"%>
-    </div>
+<div class="song-block d-flex align-items-center mb-3">
+  <div class="song-jacket d-flex align-items-center justify-content-center flex-shrink-0 me-3">
+    jacket
   </div>
-<% end %>
+  <div class="song-title">
+    <h3 class="mb-1"><%= link_to "#{pair_song.artist_list} - #{pair_song.title}", song.song_pair(pair_song), class: "text-dark" %></h3>
+  </div>
+</div>

--- a/app/views/shared/_song_block.html.erb
+++ b/app/views/shared/_song_block.html.erb
@@ -1,8 +1,29 @@
-<div class="song-block d-flex align-items-center mb-3">
-  <div class="song-jacket d-flex align-items-center justify-content-center flex-shrink-0 me-3">
-    jacket
-  </div>
-  <div class="song-title">
-    <h3 class="mb-1"><%= link_to "#{pair_song.artist_list} - #{pair_song.title}", song.song_pair(pair_song), class: "text-dark" %></h3>
-  </div>
+<div class="mb-4">
+  <% if song.pair_song_list(similarity_category: similarity_category).present? %>
+    <% song.pair_song_list(similarity_category: similarity_category, maximum: maximum).each do |pair_song| %>
+      <div class="song-block d-flex align-items-center mb-3">
+        <div class="song-jacket d-flex align-items-center justify-content-center flex-shrink-0 me-3">
+          jacket
+        </div>
+        <div class="song-title">
+          <h3 class="mb-1"><%= link_to "#{pair_song.artist_list} - #{pair_song.title}", song.song_pair(pair_song), class: "text-dark" %></h3>
+        </div>
+      </div>
+    <% end %>
+    <% if song.pair_song_list(similarity_category: similarity_category).count > maximum && maximum != 0 %>
+      <div class="more-button d-flex justify-content-center">
+        <% if similarity_category == 'melody' %>
+          <%= link_to "全て表示", melody_song_path, class: "btn" %>
+        <% elsif similarity_category == 'style' %>
+          <%= link_to "全て表示", style_song_path, class: "btn" %>
+        <% elsif similarity_category == 'sampling' %>
+          <%= link_to "全て表示", sampling_song_path, class: "btn" %>
+        <% end %>
+      </div>
+    <% end %>
+  <% else %>
+    <div class="text-center">
+      <p>このカテゴリーの楽曲は登録されていません。</p>
+    </div>
+  <% end %>
 </div>

--- a/app/views/shared/_song_block.html.erb
+++ b/app/views/shared/_song_block.html.erb
@@ -1,0 +1,14 @@
+<% song_pairs.each do |song_pair| %>
+  <div class="song-block d-flex align-items-center mb-3">
+    <div class="song-jacket d-flex align-items-center justify-content-center flex-shrink-0 me-3">
+      jacket
+    </div>
+    <div class="song-title">
+      <h3 class="mb-1"><%= link_to "#{song_pair.original_song.artist_list} - #{song_pair.original_song.title}", song_pair, class: "text-dark" %></h3>
+      <p class="mb-0">→似てる曲: <%= song_pair.similar_song.artist_list %> - <%= song_pair.similar_song.title %></p>
+    </div>
+    <div class="song-category ms-auto">
+      <%= link_to "カテゴリー: #{song_pair.similarity_category.name}", "#"%>
+    </div>
+  </div>
+<% end %>

--- a/app/views/shared/_song_pair_block.html.erb
+++ b/app/views/shared/_song_pair_block.html.erb
@@ -1,0 +1,14 @@
+<% song_pairs.each do |song_pair| %>
+  <div class="song-pair-block d-flex align-items-center mb-3">
+    <div class="song-jacket d-flex align-items-center justify-content-center flex-shrink-0 me-3">
+      jacket
+    </div>
+    <div class="song-title">
+      <h3 class="mb-1"><%= link_to "#{song_pair.original_song.artist_list} - #{song_pair.original_song.title}", song_pair, class: "text-dark" %></h3>
+      <p class="mb-0">→似てる曲: <%= song_pair.similar_song.artist_list %> - <%= song_pair.similar_song.title %></p>
+    </div>
+    <div class="song-category ms-auto">
+      <%= link_to "カテゴリー: #{song_pair.similarity_category.name}", "#"%>
+    </div>
+  </div>
+<% end %>

--- a/app/views/song_pairs/_song_info.html.erb
+++ b/app/views/song_pairs/_song_info.html.erb
@@ -1,0 +1,7 @@
+<div class="song-info-block">
+  <h3><%= link_to song_pair.title, song_pair %></h3>
+  <p>アーティスト名: <%= song_pair.artist_list %></p>
+  <p>リリース年: <%= song_pair.release_date %>年</p>
+  <%= render 'shared/media_widget', song: song_pair %>
+  <p>説明: <%= song_description %></p>
+</div>

--- a/app/views/song_pairs/index.html.erb
+++ b/app/views/song_pairs/index.html.erb
@@ -15,20 +15,7 @@
         </div>
       <% end %>
     <% else %>
-      <% @song_pairs.each do |song_pair| %>
-        <div class="song-block d-flex align-items-center mb-3">
-          <div class="song-jacket d-flex align-items-center justify-content-center flex-shrink-0 me-3">
-            jacket
-          </div>
-          <div class="song-title">
-            <h3 class="mb-1"><%= link_to "#{song_pair.original_song.artist_list} - #{song_pair.original_song.title}", song_pair, class: "text-dark" %></h3>
-            <p class="mb-0">→似てる曲: <%= song_pair.similar_song.artist_list %> - <%= song_pair.similar_song.title %></p>
-          </div>
-          <div class="song-category ms-auto">
-            <%= link_to "カテゴリー: #{song_pair.similarity_category.name}", "#"%>
-          </div>
-        </div>
-      <% end %>
+      <%= render "shared/song_block", song_pairs: @song_pairs %>
     <% end %>
   </div>
 </div>

--- a/app/views/song_pairs/index.html.erb
+++ b/app/views/song_pairs/index.html.erb
@@ -15,7 +15,7 @@
         </div>
       <% end %>
     <% else %>
-      <%= render "shared/song_block", song_pairs: @song_pairs %>
+      <%= render "shared/song_pair_block", song_pairs: @song_pairs %>
     <% end %>
   </div>
 </div>

--- a/app/views/song_pairs/recent_page.html.erb
+++ b/app/views/song_pairs/recent_page.html.erb
@@ -1,19 +1,6 @@
 <div>
   <h1 class="text-center mb-4">最近登録された曲</h1>
   <div class="mb-4">
-    <% @song_pairs.each do |song_pair| %>
-      <div class="song-block d-flex align-items-center mb-3">
-        <div class="song-jacket d-flex align-items-center justify-content-center flex-shrink-0 me-3">
-          jacket
-        </div>
-        <div class="song-title">
-          <h3 class="mb-1"><%= link_to "#{song_pair.original_song.artist_list} - #{song_pair.original_song.title}", song_pair, class: "text-dark" %></h3>
-          <p class="mb-0">→似てる曲: <%= song_pair.similar_song.artist_list %> - <%= song_pair.similar_song.title %></p>
-        </div>
-        <div class="song-category ms-auto">
-          <%= link_to "カテゴリー: #{song_pair.similarity_category.name}", "#"%>
-        </div>
-      </div>
-    <% end %>
+    <%= render "shared/song_block", song_pairs: @song_pairs %>
   </div>
 </div>

--- a/app/views/song_pairs/recent_page.html.erb
+++ b/app/views/song_pairs/recent_page.html.erb
@@ -1,6 +1,6 @@
 <div>
   <h1 class="text-center mb-4">最近登録された曲</h1>
   <div class="mb-4">
-    <%= render "shared/song_block", song_pairs: @song_pairs %>
+    <%= render "shared/song_pair_block", song_pairs: @song_pairs %>
   </div>
 </div>

--- a/app/views/song_pairs/show.html.erb
+++ b/app/views/song_pairs/show.html.erb
@@ -10,7 +10,7 @@
   </p>
 </div>
 <div>
-  <%= render 'song_info', song_pair: @song_pair.original_song, song_description: @song_pair.original_song_description %>
+  <%= render 'song_info', song: @song_pair.original_song, song_description: @song_pair.original_song_description %>
 
   <% if @song_pair.similarity_category.id == 3 %>
     <h2 class="text-center mb-4">↓サンプリングされてる</h2>
@@ -18,7 +18,7 @@
     <h2 class="text-center mb-4">↓似てる: <%= @song_pair.similarity_category.name %></h2>
   <% end %>
   
-  <%= render 'song_info', song_pair: @song_pair.similar_song, song_description: @song_pair.similar_song_description %>
+  <%= render 'song_info', song: @song_pair.similar_song, song_description: @song_pair.similar_song_description %>
   
   <div class="user-info-block">
     <h3>登録したユーザー</h3>

--- a/app/views/song_pairs/show.html.erb
+++ b/app/views/song_pairs/show.html.erb
@@ -10,11 +10,7 @@
   </p>
 </div>
 <div>
-  <h3><%= link_to @song_pair.original_song.title, @song_pair.original_song %></h3>
-  <p>アーティスト名: <%= @song_pair.original_song.artist_list %></p>
-  <p>リリース年: <%= @song_pair.original_song.release_date %>年</p>
-  <%= render 'shared/media_widget', song: @song_pair.original_song %>
-  <p>説明: <%= @song_pair.original_song_description %></p>
+  <%= render 'song_info', song_pair: @song_pair.original_song, song_description: @song_pair.original_song_description %>
 
   <% if @song_pair.similarity_category.id == 3 %>
     <h2 class="text-center mb-4">↓サンプリングされてる</h2>
@@ -22,11 +18,10 @@
     <h2 class="text-center mb-4">↓似てる: <%= @song_pair.similarity_category.name %></h2>
   <% end %>
   
-  <h3><%= link_to @song_pair.similar_song.title, @song_pair.similar_song %></h3>
-  <p>アーティスト名: <%= @song_pair.similar_song.artist_list %></p>
-  <p>リリース年: <%= @song_pair.similar_song.release_date %>年</p>
-  <%= render 'shared/media_widget', song: @song_pair.similar_song %>
-  <p>説明: <%= @song_pair.similar_song_description %></p>
-  <h3>登録したユーザー</h3>
-  <p><%= @song_pair.user.name %></p>
+  <%= render 'song_info', song_pair: @song_pair.similar_song, song_description: @song_pair.similar_song_description %>
+  
+  <div class="user-info-block">
+    <h3>登録したユーザー</h3>
+    <p><%= @song_pair.user.name %></p>
+  </div>
 </div>

--- a/app/views/songs/_song_info.html.erb
+++ b/app/views/songs/_song_info.html.erb
@@ -1,7 +1,8 @@
 <div class="mb-4 song-info-block">
-  <h3><%= link_to song.title, song %></h3>
+  <h3><%= song.title %></h3>
   <p>アーティスト名: <%= song.artist_list %></p>
   <p>リリース年: <%= song.release_date %></p>
-  <%= render 'shared/media_widget', song: song %>
-  <p>説明: <%= song_description %></p>
+  <% if media_widget %>
+    <%= render 'shared/media_widget', song: song %>
+  <% end %>
 </div>

--- a/app/views/songs/melody_song_pairs.html.erb
+++ b/app/views/songs/melody_song_pairs.html.erb
@@ -1,13 +1,5 @@
 <h1 class="text-center mb-4">楽曲情報</h1>
-<div class="mb-4 song-info-block">
-  <h3><%= @song.title %></h3>
-  <p>アーティスト名: 
-    <% @song.artists.each do |artist| %>
-      <%= artist.name %>
-    <% end %>
-  </p>
-  <p>リリース年: <%= @song.release_date %></p>
-</div>
+<%= render 'song_info', song: @song, media_widget: false %>
 <div>
   <h4 class="text-center mb-4">この曲とメロディーが似てる曲</h4>
   <%= render 'shared/song_block', song: @song, similarity_category: 'melody', maximum: 0 %>

--- a/app/views/songs/melody_song_pairs.html.erb
+++ b/app/views/songs/melody_song_pairs.html.erb
@@ -10,22 +10,5 @@
 </div>
 <div>
   <h4 class="text-center mb-4">この曲とメロディーが似てる曲</h4>
-  <div class="mb-4">
-    <% if @song.melody_pairs.present? %>
-      <% @song.melody_pairs.each do |song| %>
-        <div class="song-block d-flex align-items-center mb-3">
-            <div class="song-jacket d-flex align-items-center justify-content-center flex-shrink-0 me-3">
-              jacket
-            </div>
-            <div class="song-title">
-              <h3 class="mb-1"><%= link_to "#{song.artist_list} - #{song.title}", @song.song_pair(song), class: "text-dark" %></h3>
-            </div>
-          </div>
-      <% end %>
-    <% else %>
-      <div class="text-center">
-        <p>このカテゴリーの楽曲は登録されていません。</p>
-      </div>
-    <% end %>
-  </div>
+  <%= render 'shared/song_block', song: @song, similarity_category: 'melody', maximum: 0 %>
 </div>

--- a/app/views/songs/sampling_song_pairs.html.erb
+++ b/app/views/songs/sampling_song_pairs.html.erb
@@ -10,22 +10,5 @@
 </div>
 <div>
   <h4 class="text-center mb-4">この曲がサンプリングしてる・されてる曲</h4>
-  <div class="mb-4">
-    <% if @song.sampling_pairs.present? %>
-      <% @song.sampling_pairs.each do |song| %>
-        <div class="song-block d-flex align-items-center mb-3">
-            <div class="song-jacket d-flex align-items-center justify-content-center flex-shrink-0 me-3">
-              jacket
-            </div>
-            <div class="song-title">
-              <h3 class="mb-1"><%= link_to "#{song.artist_list} - #{song.title}", @song.song_pair(song), class: "text-dark" %></h3>
-            </div>
-          </div>
-      <% end %>
-    <% else %>
-      <div class="text-center">
-        <p>このカテゴリーの楽曲は登録されていません。</p>
-      </div>
-    <% end %>
-  </div>
+  <%= render 'shared/song_block', song: @song, similarity_category: 'sampling', maximum: 0 %>
 </div>

--- a/app/views/songs/sampling_song_pairs.html.erb
+++ b/app/views/songs/sampling_song_pairs.html.erb
@@ -1,13 +1,5 @@
 <h1 class="text-center mb-4">楽曲情報</h1>
-<div class="mb-4 song-info-block">
-  <h3><%= @song.title %></h3>
-  <p>アーティスト名: 
-    <% @song.artists.each do |artist| %>
-      <%= artist.name %>
-    <% end %>
-  </p>
-  <p>リリース年: <%= @song.release_date %></p>
-</div>
+<%= render 'song_info', song: @song, media_widget: false %>
 <div>
   <h4 class="text-center mb-4">この曲がサンプリングしてる・されてる曲</h4>
   <%= render 'shared/song_block', song: @song, similarity_category: 'sampling', maximum: 0 %>

--- a/app/views/songs/show.html.erb
+++ b/app/views/songs/show.html.erb
@@ -12,18 +12,11 @@
 <div>
   <h4 class="text-center mb-4">この曲とメロディーが似てる曲</h4>
   <div class="mb-4">
-    <% if @song.melody_pairs.present? %>
-      <% @song.melody_pairs.take(3).each do |song| %>
-        <div class="song-block d-flex align-items-center mb-3">
-            <div class="song-jacket d-flex align-items-center justify-content-center flex-shrink-0 me-3">
-              jacket
-            </div>
-            <div class="song-title">
-              <h3 class="mb-1"><%= link_to "#{song.artist_list} - #{song.title}", @song.song_pair(song), class: "text-dark" %></h3>
-            </div>
-          </div>
+    <% if @song.pair_song_list(similarity_category: 'melody').present? %>
+      <% @song.pair_song_list(similarity_category: 'melody').take(3).each do |pair_song| %>
+        <%= render 'shared/song_block', pair_song: pair_song, song: @song %>
       <% end %>
-      <% if @song.melody_pairs.count > 3 %>
+      <% if @song.pair_song_list(similarity_category: 'melody').count > 3 %>
         <div class="more-button d-flex justify-content-center">
           <%= link_to "全て表示", melody_song_path, class: "btn" %>
         </div>
@@ -38,18 +31,11 @@
 <div>
   <h4 class="text-center mb-4">この曲とジャンル・スタイルが似てる曲</h4>
   <div class="mb-4">
-    <% if @song.style_pairs.present? %>
-      <% @song.style_pairs.take(3).each do |song| %>
-        <div class="song-block d-flex align-items-center mb-3">
-            <div class="song-jacket d-flex align-items-center justify-content-center flex-shrink-0 me-3">
-              jacket
-            </div>
-            <div class="song-title">
-              <h3 class="mb-1"><%= link_to "#{song.artist_list} - #{song.title}", @song.song_pair(song), class: "text-dark" %></h3>
-            </div>
-          </div>
+    <% if @song.pair_song_list(similarity_category: 'style').present? %>
+      <% @song.pair_song_list(similarity_category: 'style').take(3).each do |pair_song| %>
+        <%= render 'shared/song_block', pair_song: pair_song, song: @song %>
       <% end %>
-      <% if @song.style_pairs.count > 3 %>
+      <% if @song.pair_song_list(similarity_category: 'style').count > 3 %>
         <div class="more-button d-flex justify-content-center">
           <%= link_to "全て表示", style_song_path, class: "btn" %>
         </div>
@@ -64,18 +50,11 @@
 <div>
   <h4 class="text-center mb-4">この曲がサンプリングしてる・されてる曲</h4>
   <div class="mb-4">
-    <% if @song.sampling_pairs.present? %>
-      <% @song.sampling_pairs.take(3).each do |song| %>
-        <div class="song-block d-flex align-items-center mb-3">
-            <div class="song-jacket d-flex align-items-center justify-content-center flex-shrink-0 me-3">
-              jacket
-            </div>
-            <div class="song-title">
-              <h3 class="mb-1"><%= link_to "#{song.artist_list} - #{song.title}", @song.song_pair(song), class: "text-dark" %></h3>
-            </div>
-          </div>
+    <% if @song.pair_song_list(similarity_category: 'sampling').present? %>
+      <% @song.pair_song_list(similarity_category: 'sampling').take(3).each do |pair_song| %>
+        <%= render 'shared/song_block', pair_song: pair_song, song: @song %>
       <% end %>
-      <% if @song.sampling_pairs.count > 3 %>
+      <% if @song.pair_song_list(similarity_category: 'sampling').count > 3 %>
         <div class="more-button d-flex justify-content-center">
           <%= link_to "全て表示", sampling_song_path, class: "btn" %>
         </div>

--- a/app/views/songs/show.html.erb
+++ b/app/views/songs/show.html.erb
@@ -1,14 +1,5 @@
 <h1 class="text-center mb-4">楽曲情報</h1>
-<div class="mb-4 song-info-block">
-  <h3><%= @song.title %></h3>
-  <p>アーティスト名: 
-    <% @song.artists.each do |artist| %>
-      <%= artist.name %>
-    <% end %>
-  </p>
-  <p>リリース年: <%= @song.release_date %></p>
-  <%= render 'shared/media_widget', song: @song %>
-</div>
+<%= render 'song_info', song: @song, media_widget: true %>
 <div>
   <h4 class="text-center mb-4">この曲とメロディーが似てる曲</h4>
   <%= render 'shared/song_block', song: @song, similarity_category: 'melody', maximum: 3 %>

--- a/app/views/songs/show.html.erb
+++ b/app/views/songs/show.html.erb
@@ -11,58 +11,13 @@
 </div>
 <div>
   <h4 class="text-center mb-4">この曲とメロディーが似てる曲</h4>
-  <div class="mb-4">
-    <% if @song.pair_song_list(similarity_category: 'melody').present? %>
-      <% @song.pair_song_list(similarity_category: 'melody').take(3).each do |pair_song| %>
-        <%= render 'shared/song_block', pair_song: pair_song, song: @song %>
-      <% end %>
-      <% if @song.pair_song_list(similarity_category: 'melody').count > 3 %>
-        <div class="more-button d-flex justify-content-center">
-          <%= link_to "全て表示", melody_song_path, class: "btn" %>
-        </div>
-      <% end %>
-    <% else %>
-      <div class="text-center">
-        <p>このカテゴリーの楽曲は登録されていません。</p>
-      </div>
-    <% end %>
-  </div>
+  <%= render 'shared/song_block', song: @song, similarity_category: 'melody', maximum: 3 %>
 </div>
 <div>
   <h4 class="text-center mb-4">この曲とジャンル・スタイルが似てる曲</h4>
-  <div class="mb-4">
-    <% if @song.pair_song_list(similarity_category: 'style').present? %>
-      <% @song.pair_song_list(similarity_category: 'style').take(3).each do |pair_song| %>
-        <%= render 'shared/song_block', pair_song: pair_song, song: @song %>
-      <% end %>
-      <% if @song.pair_song_list(similarity_category: 'style').count > 3 %>
-        <div class="more-button d-flex justify-content-center">
-          <%= link_to "全て表示", style_song_path, class: "btn" %>
-        </div>
-      <% end %>
-    <% else %>
-      <div class="text-center">
-        <p>このカテゴリーの楽曲は登録されていません。</p>
-      </div>
-    <% end %>
-  </div>
+  <%= render 'shared/song_block', song: @song, similarity_category: 'style', maximum: 3 %>
 </div>
 <div>
   <h4 class="text-center mb-4">この曲がサンプリングしてる・されてる曲</h4>
-  <div class="mb-4">
-    <% if @song.pair_song_list(similarity_category: 'sampling').present? %>
-      <% @song.pair_song_list(similarity_category: 'sampling').take(3).each do |pair_song| %>
-        <%= render 'shared/song_block', pair_song: pair_song, song: @song %>
-      <% end %>
-      <% if @song.pair_song_list(similarity_category: 'sampling').count > 3 %>
-        <div class="more-button d-flex justify-content-center">
-          <%= link_to "全て表示", sampling_song_path, class: "btn" %>
-        </div>
-      <% end %>
-    <% else %>
-      <div class="text-center">
-        <p>このカテゴリーの楽曲は登録されていません。</p>
-      </div>
-    <% end %>
-  </div>
+  <%= render 'shared/song_block', song: @song, similarity_category: 'sampling', maximum: 3 %>
 </div>

--- a/app/views/songs/style_song_pairs.html.erb
+++ b/app/views/songs/style_song_pairs.html.erb
@@ -1,13 +1,5 @@
 <h1 class="text-center mb-4">楽曲情報</h1>
-<div class="mb-4 song-info-block">
-  <h3><%= @song.title %></h3>
-  <p>アーティスト名: 
-    <% @song.artists.each do |artist| %>
-      <%= artist.name %>
-    <% end %>
-  </p>
-  <p>リリース年: <%= @song.release_date %></p>
-</div>
+<%= render 'song_info', song: @song, media_widget: false %>
 <div>
   <h4 class="text-center mb-4">この曲とジャンル・スタイルが似てる曲</h4>
   <%= render 'shared/song_block', song: @song, similarity_category: 'style', maximum: 0 %>

--- a/app/views/songs/style_song_pairs.html.erb
+++ b/app/views/songs/style_song_pairs.html.erb
@@ -10,22 +10,5 @@
 </div>
 <div>
   <h4 class="text-center mb-4">この曲とジャンル・スタイルが似てる曲</h4>
-  <div class="mb-4">
-    <% if @song.style_pairs.present? %>
-      <% @song.style_pairs.each do |song| %>
-        <div class="song-block d-flex align-items-center mb-3">
-            <div class="song-jacket d-flex align-items-center justify-content-center flex-shrink-0 me-3">
-              jacket
-            </div>
-            <div class="song-title">
-              <h3 class="mb-1"><%= link_to "#{song.artist_list} - #{song.title}", @song.song_pair(song), class: "text-dark" %></h3>
-            </div>
-          </div>
-      <% end %>
-    <% else %>
-      <div class="text-center">
-        <p>このカテゴリーの楽曲は登録されていません。</p>
-      </div>
-    <% end %>
-  </div>
+  <%= render 'shared/song_block', song: @song, similarity_category: 'style', maximum: 0 %>
 </div>


### PR DESCRIPTION
# 概要
既存のViewの共通部分をテンプレート化

# 詳細
各ページ用に以下のテンプレートを作成
- `shared/_song_block.html.erb` : 一覧系ページの単曲用ブロックのテンプレート
- `shared/_song_pair_block.html.erb` : 一覧系ページの組み合わせ曲用ブロックのテンプレート
- `song_pairs/_song_info.html.erb` : 似てる曲組み合わせページ内の楽曲情報ブロックのテンプレート
- `songs/_song_info.html.erb` : 楽曲ページ内の楽曲情報ブロックのテンプレート