### PR TITLE
楽曲のジャケットの取得と表示

### DIFF
--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -12,6 +12,15 @@
     }
 }
 
+.container {
+    max-width: 1000px;
+}
+
+iframe {
+    width: 100%;
+    aspect-ratio: 16 / 9;
+}
+
 body {
     background-color: #313338;
 }
@@ -57,29 +66,57 @@ footer {
     border-radius: 7px;
     margin-bottom: 10px;
     display: flex;
-}
-
-.song-jacket-container {
-    border-radius: 7px 0px 0px 7px;
-    width: 75px;
-    height: 75px;
-    overflow: hidden;
-    position: relative;
-    .song-jacket {
-        clip-path: inset(45px 105px 45px 105px);
-        transform: scale(0.28);
-        object-fit: cover;
+    .song-jacket-container {
+        border-radius: 7px 0px 0px 7px;
+        width: 75px;
+        height: 75px;
+        overflow: hidden;
+        position: relative;
+        .song-jacket {
+            clip-path: inset(45px 105px 45px 105px);
+            transform: scale(0.28);
+            object-fit: cover;
+        }
     }
 }
 
-// .song-title {
-//     margin-top: auto;
-//     margin-bottom: auto;
-//     margin-left: 10px;
-//     h3, p {
-//         margin: 0px;
-//     }
-// }
+.song-info-block {
+    background-color: #fff;
+    color: #000;
+    border-radius: 7px;
+    padding: 1em 2em;
+    p {
+        margin-bottom: 0;
+    }
+    .song-info {
+        height: 96px;
+    }
+    .song-jacket-container {
+        background-color: #FF7171;
+        border-radius: 7px;
+        width: 96px;
+        height: 96px;
+        overflow: hidden;
+        position: relative;
+        .song-jacket {
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            clip-path: inset(45px 105px 45px 105px);
+            transform: translate(-50%, -50%) scale(0.4);
+            object-fit: cover;
+        }
+    }
+    .song-description {
+        p {
+            min-height: 3em;
+        }
+    }
+}
+
+.media-widget {
+    margin-top: 1em;
+}
 
 .song-category {
     margin-right: 10px;

--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -57,17 +57,20 @@ footer {
     border-radius: 7px;
     margin-bottom: 10px;
     display: flex;
-    .song-jacket {
-        border-radius: 7px 0px 0px 7px;
-        width: 75px;
-        height: 75px;
-        background-color: #FF7171;
-        justify-content: center;
-        align-items: center;
-        color: #fff;
-    }
 }
 
+.song-jacket-container {
+    border-radius: 7px 0px 0px 7px;
+    width: 75px;
+    height: 75px;
+    overflow: hidden;
+    position: relative;
+    .song-jacket {
+        clip-path: inset(45px 105px 45px 105px);
+        transform: scale(0.28);
+        object-fit: cover;
+    }
+}
 
 // .song-title {
 //     margin-top: auto;

--- a/app/views/shared/_media_widget.html.erb
+++ b/app/views/shared/_media_widget.html.erb
@@ -1,5 +1,7 @@
-<% if song.media_url_id.present? %>
-    <iframe width="800" height="450" src="https://www.youtube.com/embed/<%= song.media_url_id %>" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-<% else %>
-  <p>YouTubeの動画が見つかりません。</p>
-<% end %>
+<div class="media-widget">
+  <% if song.media_url_id.present? %>
+      <iframe src="https://www.youtube.com/embed/<%= song.media_url_id %>" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+  <% else %>
+    <p>YouTubeの動画が見つかりません。</p>
+  <% end %>
+</div>

--- a/app/views/shared/_song_block.html.erb
+++ b/app/views/shared/_song_block.html.erb
@@ -2,8 +2,8 @@
   <% if song.pair_song_list(similarity_category: similarity_category).present? %>
     <% song.pair_song_list(similarity_category: similarity_category, maximum: maximum).each do |pair_song| %>
       <div class="song-block d-flex align-items-center mb-3">
-        <div class="song-jacket d-flex align-items-center justify-content-center flex-shrink-0 me-3">
-          jacket
+        <div class="song-jacket-container d-flex align-items-center justify-content-center flex-shrink-0 me-3">
+          <%= image_tag "https://img.youtube.com/vi/#{pair_song.media_url_id}/hqdefault.jpg", class: "song-jacket" %>
         </div>
         <div class="song-title">
           <h3 class="mb-1"><%= link_to "#{pair_song.artist_list} - #{pair_song.title}", song.song_pair(pair_song), class: "text-dark" %></h3>

--- a/app/views/shared/_song_pair_block.html.erb
+++ b/app/views/shared/_song_pair_block.html.erb
@@ -1,7 +1,8 @@
 <% song_pairs.take(defined?(maximum) && maximum || song_pairs.size).each do |song_pair| %>
   <div class="song-pair-block d-flex align-items-center mb-3">
-    <div class="song-jacket d-flex align-items-center justify-content-center flex-shrink-0 me-3">
-      jacket
+    <div class="song-jacket-container d-flex align-items-center justify-content-center flex-shrink-0 me-3">
+      <%# jacket %>
+      <%= image_tag "https://img.youtube.com/vi/#{song_pair.original_song.media_url_id}/hqdefault.jpg", class: "song-jacket" %>
     </div>
     <div class="song-title">
       <h3 class="mb-1"><%= link_to "#{song_pair.original_song.artist_list} - #{song_pair.original_song.title}", song_pair, class: "text-dark" %></h3>

--- a/app/views/song_pairs/_song_info.html.erb
+++ b/app/views/song_pairs/_song_info.html.erb
@@ -1,7 +1,17 @@
 <div class="mb-4 song-info-block">
-  <h3><%= link_to song.title, song %></h3>
-  <p>アーティスト名: <%= song.artist_list %></p>
-  <p>リリース年: <%= song.release_date %></p>
+  <div class="d-flex">
+    <div class="song-info">
+      <h3><%= link_to song.title, song %></h3>
+      <p>アーティスト名: <%= song.artist_list %></p>
+      <p>リリース年: <%= song.release_date %></p>
+    </div>
+    <div class="song-jacket-container ms-auto">
+      <%= image_tag "https://img.youtube.com/vi/#{song.media_url_id}/hqdefault.jpg", class: "song-jacket" %>
+    </div>
+  </div>
   <%= render 'shared/media_widget', song: song %>
-  <p>説明: <%= song_description %></p>
+  <div class="song-description">
+    <h5>説明:</h5>
+    <p><%= song_description %></p>
+  </div>
 </div>

--- a/app/views/songs/_song_info.html.erb
+++ b/app/views/songs/_song_info.html.erb
@@ -1,7 +1,14 @@
 <div class="mb-4 song-info-block">
-  <h3><%= song.title %></h3>
-  <p>アーティスト名: <%= song.artist_list %></p>
-  <p>リリース年: <%= song.release_date %></p>
+  <div class="d-flex">
+    <div class="song-info">
+      <h3><%= song.title %></h3>
+      <p>アーティスト名: <%= song.artist_list %></p>
+      <p>リリース年: <%= song.release_date %></p>
+    </div>
+    <div class="song-jacket-container ms-auto">
+      <%= image_tag "https://img.youtube.com/vi/#{song.media_url_id}/hqdefault.jpg", class: "song-jacket" %>
+    </div>
+  </div>
   <% if media_widget %>
     <%= render 'shared/media_widget', song: song %>
   <% end %>


### PR DESCRIPTION
# 概要
各楽曲の項目に楽曲のジャケットと表示

# 詳細
`Song`テーブルに保存された`media_url`カラム(YouTubeのURL)から動画のサムネイル画像を取得し、CSSで整形した上で楽曲のジャケットとして各項目に表示
以下ページに使用
- トップページの楽曲一覧
- 楽曲ページ
- 似てる曲・サンプリング曲の組み合わせページ