### PR TITLE
楽曲ページから楽曲登録ページへ移動する機能の実装

### DIFF
--- a/app/controllers/song_pairs_controller.rb
+++ b/app/controllers/song_pairs_controller.rb
@@ -17,10 +17,16 @@ class SongPairsController < ApplicationController
 
   def new
     @song_pair = SongPair.new
-    @song_pair.build_original_song
+    if params[:original_song_id]
+      original_song = Song.find(params[:original_song_id])
+      @song_pair.build_original_song(title: original_song.title, release_date: original_song.release_date, media_url: original_song.media_url)
+      @song_pair.original_song.artists.build(name: original_song.artist_list)
+    else
+      @song_pair.build_original_song
+      @song_pair.original_song.artists.build if @song_pair.original_song.artists.blank?
+    end
+    
     @song_pair.build_similar_song
-
-    @song_pair.original_song.artists.build if @song_pair.original_song.artists.blank?
     @song_pair.similar_song.artists.build if @song_pair.similar_song.artists.blank?
 
     @categories = SimilarityCategory.all

--- a/app/javascript/media_widget.js
+++ b/app/javascript/media_widget.js
@@ -37,7 +37,7 @@ document.addEventListener("turbo:load", () => {
 
     if (mediaId) {
       const embedUrl = `https://www.youtube.com/embed/${mediaId}`;
-      const iframeHtml = `<iframe width="560" height="315" src="${embedUrl}" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>`;
+      const iframeHtml = `<div class="media-widget"><iframe src="${embedUrl}" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>`;
       playerElement.innerHTML = iframeHtml;
     } else {
       playerElement.innerHTML = '';

--- a/app/views/songs/_song_info.html.erb
+++ b/app/views/songs/_song_info.html.erb
@@ -12,4 +12,11 @@
   <% if media_widget %>
     <%= render 'shared/media_widget', song: song %>
   <% end %>
+  <div class="normal-button d-flex justify-content-center">
+    <% if logged_in? %>
+      <%= link_to "この曲と似てる楽曲を登録", new_song_pair_path(original_song_id: song.id) %>
+    <% else %>
+      <%= link_to "アカウント登録・ログインをしてこの曲と似てる楽曲を登録", signup_path %>
+    <% end %>
+  </div>
 </div>


### PR DESCRIPTION
# 概要
楽曲ページから楽曲登録ページへ移動し、予め楽曲情報がフォームに入力される機能を実装

# 詳細
特定の楽曲ページ(song_path)から楽曲登録ページ(new_song_pair_path)へ移動する機能を実装
- 楽曲ページ内に楽曲登録ページへのリンクを設置
- リンクから楽曲登録ページへ移動するとリンク元の楽曲ページの楽曲情報が入力フォームの`曲情報1`に自動で入力

## その他
- 楽曲登録ページ内の動画表示部分(`media_widget`)の修正