### PR TITLE
一覧系ページの絞り込み・並べ替え機能の実装

### DIFF
--- a/app/controllers/song_pairs_controller.rb
+++ b/app/controllers/song_pairs_controller.rb
@@ -8,11 +8,13 @@ class SongPairsController < ApplicationController
   end
   
   def recent_page
-    @song_pairs = SongPair.includes(:similarity_category, :original_song => :artists, :similar_song => :artists).order(created_at: :desc)
+    @q = SongPair.ransack(params[:q])
+    @song_pairs = @q.result(distinct: true).includes(:similarity_category, :original_song => :artists, :similar_song => :artists).order(created_at: :desc)
   end
 
   def popularity_page
-    @song_pairs = SongPair.includes(:similarity_category, :original_song => :artists, :similar_song => :artists).sort_by{ |song_pair| song_pair.page_view_count(request.base_url) }.reverse
+    @q = SongPair.ransack(params[:q])
+    @song_pairs = @q.result(distinct: true).includes(:similarity_category, :original_song => :artists, :similar_song => :artists).sort_by{ |song_pair| song_pair.page_view_count(request.base_url) }.reverse
   end
 
   def new

--- a/app/views/shared/_filter.html.erb
+++ b/app/views/shared/_filter.html.erb
@@ -1,4 +1,4 @@
-<%= form_with method: :get, local: true, class: "mb-4" do %>
+<%= form_with method: :get, local: true do %>
   <div class="d-flex align-items-center">
     <%= label_tag :category, "カテゴリー:" %>
     <%= select_tag "q[similarity_category_id_eq]", options_from_collection_for_select(SimilarityCategory.all, :id, :name, params.dig(:q, :similarity_category_id_eq)), include_blank: "全て", onchange: "this.form.submit()", class: "mx-2" %>

--- a/app/views/shared/_filter.html.erb
+++ b/app/views/shared/_filter.html.erb
@@ -1,0 +1,6 @@
+<%= form_with method: :get, local: true, class: "mb-4" do %>
+  <div class="d-flex align-items-center">
+    <%= label_tag :category, "カテゴリー:" %>
+    <%= select_tag "q[similarity_category_id_eq]", options_from_collection_for_select(SimilarityCategory.all, :id, :name, params.dig(:q, :similarity_category_id_eq)), include_blank: "全て", onchange: "this.form.submit()", class: "mx-2" %>
+  </div>
+<% end %>

--- a/app/views/shared/_song_pair_block.html.erb
+++ b/app/views/shared/_song_pair_block.html.erb
@@ -1,7 +1,6 @@
 <% song_pairs.take(defined?(maximum) && maximum || song_pairs.size).each do |song_pair| %>
   <div class="song-pair-block d-flex align-items-center mb-3">
     <div class="song-jacket-container d-flex align-items-center justify-content-center flex-shrink-0 me-3">
-      <%# jacket %>
       <%= image_tag "https://img.youtube.com/vi/#{song_pair.original_song.media_url_id}/hqdefault.jpg", class: "song-jacket" %>
     </div>
     <div class="song-title">

--- a/app/views/shared/_sort_with_filter.html.erb
+++ b/app/views/shared/_sort_with_filter.html.erb
@@ -1,0 +1,10 @@
+<%= form_with method: :get, local: true, class: "mb-4" do %>
+  <%= hidden_field_tag "q[original_song_title_or_similar_song_title_or_original_song_artist_list_cont]", params.dig(:q, :original_song_title_or_similar_song_title_or_original_song_artist_list_cont) %>
+  <div class="d-flex align-items-center">
+    <%= label_tag :sort_by, "並べ替え:" %>
+    <%= select_tag :sort_by, options_for_select([["曲名", "song_title"], ["アーティスト名", "artist_name"], ["登録日", "created_at"]], selected: params[:sort_by] || "created_at"), onchange: "this.form.submit()", class: "mx-2" %>
+    <%= select_tag :order, options_for_select([["降順", "desc"], ["昇順", "asc"]], selected: params[:order] || "desc"), onchange: "this.form.submit()", class: "mx-2" %>
+    <%= label_tag :category, "カテゴリー:" %>
+    <%= select_tag "q[similarity_category_id_eq]", options_from_collection_for_select(SimilarityCategory.all, :id, :name, params.dig(:q, :similarity_category_id_eq)), include_blank: "全て", onchange: "this.form.submit()", class: "mx-2" %>
+  </div>
+<% end %>

--- a/app/views/shared/_sort_with_filter.html.erb
+++ b/app/views/shared/_sort_with_filter.html.erb
@@ -1,4 +1,4 @@
-<%= form_with method: :get, local: true, class: "mb-4" do %>
+<%= form_with method: :get, local: true do %>
   <%= hidden_field_tag "q[original_song_title_or_similar_song_title_or_original_song_artist_list_cont]", params.dig(:q, :original_song_title_or_similar_song_title_or_original_song_artist_list_cont) %>
   <div class="d-flex align-items-center">
     <%= label_tag :sort_by, "並べ替え:" %>

--- a/app/views/song_pairs/index.html.erb
+++ b/app/views/song_pairs/index.html.erb
@@ -1,5 +1,8 @@
 <div>
   <h1 class="text-center mb-4">検索結果</h1>
+  <div class="d-flex justify-content-center">
+    <%= render "shared/sort_with_filter" %>
+  </div>
   <div class="mb-4">
     <% if @song_pairs.blank? %>
       <div class="text-center mb-3">

--- a/app/views/song_pairs/index.html.erb
+++ b/app/views/song_pairs/index.html.erb
@@ -1,7 +1,11 @@
 <div>
   <h1 class="text-center mb-4">検索結果</h1>
-  <div class="d-flex justify-content-center">
-    <%= render "shared/sort_with_filter" %>
+  <div class="d-flex justify-content-center mb-4">
+    <% if logged_in? %>
+      <%= render "shared/sort_with_filter" %>
+    <% else %>
+      <%= link_to "アカウント登録・ログインをして並べ替え機能を使う", signup_path %>
+    <% end %>
   </div>
   <div class="mb-4">
     <% if @song_pairs.blank? %>

--- a/app/views/song_pairs/popularity_page.html.erb
+++ b/app/views/song_pairs/popularity_page.html.erb
@@ -1,5 +1,8 @@
 <div>
   <h1 class="text-center mb-4">人気曲</h1>
+  <div class="d-flex justify-content-center">
+    <%= render "shared/filter" %>
+  </div>
   <div class="mb-4">
     <%= render "shared/song_pair_block", song_pairs: @song_pairs %>
   </div>

--- a/app/views/song_pairs/popularity_page.html.erb
+++ b/app/views/song_pairs/popularity_page.html.erb
@@ -1,6 +1,6 @@
 <div>
   <h1 class="text-center mb-4">人気曲</h1>
-  <div class="d-flex justify-content-center">
+  <div class="d-flex justify-content-center mb-4">
     <%= render "shared/filter" %>
   </div>
   <div class="mb-4">

--- a/app/views/song_pairs/recent_page.html.erb
+++ b/app/views/song_pairs/recent_page.html.erb
@@ -1,6 +1,6 @@
 <div>
   <h1 class="text-center mb-4">最近登録された曲</h1>
-  <div class="d-flex justify-content-center">
+  <div class="d-flex justify-content-center mb-4">
     <%= render "shared/filter" %>
   </div>
   <div class="mb-4">

--- a/app/views/song_pairs/recent_page.html.erb
+++ b/app/views/song_pairs/recent_page.html.erb
@@ -1,5 +1,8 @@
 <div>
   <h1 class="text-center mb-4">最近登録された曲</h1>
+  <div class="d-flex justify-content-center">
+    <%= render "shared/filter" %>
+  </div>
   <div class="mb-4">
     <%= render "shared/song_pair_block", song_pairs: @song_pairs %>
   </div>


### PR DESCRIPTION
# 概要
一覧系ページで絞り込みと並べ替えが出来る機能を実装

# 詳細
実装対象のページは以下
- 検索結果ページ
- 最近登録された曲ページ
- 人気曲ページ

絞り込みでは`song_pair`テーブルの`similarity_category_id`を元にした絞り込みを、
並べ替えでは以下を元に並べ替えが出来るように設定
- 曲名(`song_pair`テーブルの`original_song`に紐づいている`song`テーブルのデータの`title`)
- アーティスト名(`song_pair`テーブルの`original_song`に紐づいている`song`テーブルのデータの`artists`)
- 登録日(`song_pair`テーブルの`created_at`)

また、未ログインユーザーは絞り込みと並べ替え機能が使用出来ないように設定