### PR TITLE
楽曲登録フォームのステップ入力化

### DIFF
--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -184,3 +184,7 @@ footer {
 .alert {
     border-radius: 0;
 }
+
+.hidden {
+    display: none;
+}

--- a/app/controllers/song_pairs_controller.rb
+++ b/app/controllers/song_pairs_controller.rb
@@ -51,6 +51,8 @@ class SongPairsController < ApplicationController
     @song_pair.similar_song.artists.build if @song_pair.similar_song.artists.blank?
 
     @categories = SimilarityCategory.all
+
+    @current_step = 0
   end
 
   def create
@@ -71,17 +73,13 @@ class SongPairsController < ApplicationController
 
         if @song_pair.save
           redirect_to @song_pair, notice: '曲のペアが登録されました'
-        else
-          @song_pair.errors.merge!(e.record.errors)
-          @categories = SimilarityCategory.all
-          render :new, status: :unprocessable_entity
-          flash[:alert] = "入力に誤りがあります"
         end
-
+        
       rescue ActiveRecord::RecordInvalid => e
-        # バリデーションエラーが発生した場合にフォームを再表示
         @song_pair.errors.merge!(e.record.errors)
         @categories = SimilarityCategory.all
+        @current_step = 2
+        flash.now[:alert] = "入力に誤りがあります"
         render :new, status: :unprocessable_entity
       end
     end

--- a/app/javascript/controllers/autocomplete_controller.js
+++ b/app/javascript/controllers/autocomplete_controller.js
@@ -13,7 +13,6 @@ export default class extends Controller {
     fetch(`/songs/autocomplete?query=${query}`)
       .then(response => response.json())
       .then(data => {
-        console.log("Artist autocomplete results:", data);
         this.showSuggestions(this.currentSongListTarget(), data, (suggestion) => {
           this.setSongData(suggestion)
         })
@@ -21,9 +20,7 @@ export default class extends Controller {
   }
 
   searchArtist() {
-    console.log("Input target for artist:", this.inputTarget);
     const query = this.artistInputTarget.value
-    console.log("Search query for artist:", query);
     if (query.length < 2) {
       this.clearSuggestions(this.currentArtistListTarget())
       return
@@ -32,7 +29,6 @@ export default class extends Controller {
     fetch(`/artists/autocomplete?query=${query}`)
       .then(response => response.json())
       .then(data => {
-        console.log("Artist autocomplete results:", data);
         this.showSuggestions(this.currentArtistListTarget(), data, (suggestion) => {
           this.artistInputTarget.value = suggestion
         })
@@ -42,13 +38,10 @@ export default class extends Controller {
   // 現在の入力フィールドに対応する曲候補リストを取得
   currentSongListTarget() {
     if (this.hasSongList1Target && this.songInputTarget.dataset.target === "autocomplete.songInput") {
-      // console.log("Song list target 1 found:", this.songList1Target);
       return this.songList1Target
     } else if (this.hasSongList2Target && this.songInputTarget.dataset.target === "autocomplete.songInput") {
-      // console.log("Song list target 2 found:", this.songList2Target);
       return this.songList2Target
     } else {
-      // console.log("No song list target found");
       return null;
     }
   }
@@ -56,10 +49,8 @@ export default class extends Controller {
   // 現在の入力フィールドに対応するアーティスト候補リストを取得
   currentArtistListTarget() {
     if (this.hasArtistList1Target && this.artistInputTarget.dataset.target === "autocomplete.artistInput") {
-      console.log("Artist list target 1 found:", this.artistList1Target);
       return this.artistList1Target
     } else if (this.hasArtistList2Target && this.artistInputTarget.dataset.target === "autocomplete.artistInput") {
-      console.log("Artist list target 2 found:", this.artistList2Target);
       return this.artistList2Target
     }
   }

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -9,3 +9,6 @@ application.register("hello", HelloController)
 
 import AutoCompleteController from "./autocomplete_controller"
 application.register("autocomplete", AutoCompleteController)
+
+import MultiStepFormController from "./multi_step_form_controller"
+application.register("multi-step-form", MultiStepFormController)

--- a/app/javascript/controllers/multi_step_form_controller.js
+++ b/app/javascript/controllers/multi_step_form_controller.js
@@ -1,0 +1,31 @@
+import { Controller } from "@hotwired/stimulus"
+export default class extends Controller {
+  static targets = ["step"]
+
+  connect() {
+    const currentStepIndex = parseInt(this.element.dataset.currentStep, 10) || 0
+    this.currentStepIndex = currentStepIndex
+    this.totalSteps = this.stepTargets.length
+    this.showStep(this.currentStepIndex)
+  }
+
+  showStep(index) {
+    // 全ステップを非表示にしてから、現在のステップだけを表示
+    this.stepTargets.forEach((step, i) => {
+      step.classList.toggle("hidden", i !== index)
+    })
+    this.currentStepIndex = index
+  }
+
+  nextStep() {
+    if (this.currentStepIndex < this.totalSteps - 1) {
+      this.showStep(this.currentStepIndex + 1)
+    }
+  }
+
+  previousStep() {
+    if (this.currentStepIndex > 0) {
+      this.showStep(this.currentStepIndex - 1)
+    }
+  }
+}

--- a/app/views/song_pairs/new.html.erb
+++ b/app/views/song_pairs/new.html.erb
@@ -1,90 +1,136 @@
 <h1 class="text-center mb-4">楽曲を登録</h1>
-<%= form_with model: @song_pair, local: true, class: "form-signin", data: { turbo: false } do |f| %>
-   <% if @song_pair.errors.any? %>
-    <div id="error_explanation" class="alert alert-danger">
-      <ul>
-        <% @song_pair.errors.each do |error| %>
-          <li><%= error.full_message %></li>
+<%= form_with model: @song_pair, local: true, class: "form-signin", data: { turbo: false, controller: "multi-step-form", current_step: @current_step } do |f| %>
+  <%# 注意事項 %>
+  <div data-multi-step-form-target="step">
+    <h3 class="text-center mb-4">登録する上での注意</h3>
+    <div class="text-center mb-4">
+      <p>本サービスはあくまで楽曲探しや楽曲そのものを『楽しむ』為に提供するものです。<br>
+      作品の『盗作』や『パクリ』を指摘したり推奨するものではありません。<br>
+      楽曲やアーティストに対する悪意のある書き込み等は残すことのないようお願いします。<br>
+      誰が見ても純粋に「あ！似てる！面白い！」と思えるようなコンテンツにしていきましょう。</p>
+    </div>
+    <div>
+      <%= button_tag "次に進む", type: "button", data: { action: "multi-step-form#nextStep" }, class: "btn btn-primary btn-block" %>
+    </div>
+  </div>
+
+  <%# カテゴリー選択 %>
+  <div data-multi-step-form-target="step" class="hidden">
+    <div class="mb-3">
+      <%= f.collection_select :similarity_category_id, @categories, :id, :name, {}, { class: 'form-select' } %>
+    </div>
+    <h3 class="text-center mb-4">カテゴリーについて</h3>
+    <div class="text-center mb-4">
+      <p>カテゴリーは『どんな風に似ているのか』を分類する為に設定するものです。</p>
+      <p>何が似ているかを定義するものにもなります。</p>
+      <p>各カテゴリーの説明を元にどのカテゴリーに当てはまるかを参考にしてください。</p>
+      <br>
+      <h4>メロディ</h4>
+      <p>楽曲内のメロディ部分が似ている場合はこちらのカテゴリーを選んでください。</p>
+      <p>楽器が演奏していてもボーカルが歌っていてもメロディであればOKです。</p>
+      <br>
+      <h4>ジャンル・スタイル</h4>
+      <p>楽曲内で使用されている楽器やエフェクトの使い方、ボーカルの歌い方等、音楽ジャンルとしてや楽曲のスタイルが似ている場合にはこちらのカテゴリーを選んでください。</p>
+      <p>「言葉じゃ説明しにくいけどなんか似てる…」という場合はこちらが当てはまる場合が多いかもしれません。</p>
+      <br>
+      <h4>サンプリング</h4>
+      <p>楽曲内で別の楽曲の音源が一部分使われていたりする場合はこちらを選んでください。</p>
+      <p>サンプリングのされ方は様々で『ボーカル部分だけ使われている』、『ドラム部分だけ使われている』、『イントロ部分だけ使われている』など既存の楽曲音源を部分的に使用することでただ楽器を演奏したり、歌うだけでは出来ない新しい表現を生み出すことができます。</p>
+      <p>イメージしづらい場合はサンプリングカテゴリーで登録されている楽曲を実際に参考にしてみてください。</p>
+    </div>
+    <div>
+      <%= button_tag "次に進む", type: "button", data: { action: "multi-step-form#nextStep" }, class: "btn btn-primary btn-block" %>
+    </div>
+  </div>
+
+  <%# 曲情報入力 %>
+  <div data-multi-step-form-target="step" class="hidden">
+    <% if @song_pair.errors.any? %>
+      <div id="error_explanation" class="alert alert-danger">
+        <ul>
+          <% @song_pair.errors.each do |error| %>
+            <li><%= error.full_message %></li>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>
+
+    <h3 class="text-center mb-4">曲情報1</h3>
+    <p class="text-center">曲の情報を入力してください。</p>
+    <div data-controller="autocomplete">
+      <%= f.fields_for :original_song do |song1_form| %>
+        <div class="mb-3">
+          <%= song1_form.label :title, "曲名", class: "form-label" %>
+          <%= song1_form.text_field :title, class: "form-control", data: { action: "input->autocomplete#search", target: "autocomplete.songInput" } %>
+          <ul data-autocomplete-target="songList1" class="autocomplete-list"></ul>
+        </div>
+        <%= song1_form.fields_for :artists do |artist1_form| %>
+          <div class="mb-3">
+            <%= artist1_form.label :name, "アーティスト名", class: "form-label" %>
+            <%= artist1_form.text_field :name, class: "form-control", data: { action: "input->autocomplete#searchArtist", target: "autocomplete.artistInput" } %>
+            <ul data-autocomplete-target="artistList1" class="autocomplete-list"></ul>
+          </div>
         <% end %>
-      </ul>
-    </div>
-  <% end %>
-
-  <h3 class="text-center mb-4">曲情報1</h3>
-  <div data-controller="autocomplete">
-    <%= f.fields_for :original_song do |song1_form| %>
-      <div class="mb-3">
-        <%= song1_form.label :title, "曲名", class: "form-label" %>
-        <%= song1_form.text_field :title, class: "form-control", data: { action: "input->autocomplete#search", target: "autocomplete.songInput" } %>
-        <ul data-autocomplete-target="songList1" class="autocomplete-list"></ul>
-      </div>
-      <%= song1_form.fields_for :artists do |artist1_form| %>
         <div class="mb-3">
-          <%= artist1_form.label :name, "アーティスト名", class: "form-label" %>
-          <%= artist1_form.text_field :name, class: "form-control", data: { action: "input->autocomplete#searchArtist", target: "autocomplete.artistInput" } %>
-          <ul data-autocomplete-target="artistList1" class="autocomplete-list"></ul>
+          <%= song1_form.label :release_date, "リリース年", class: "form-label" %>
+          <%= song1_form.number_field :release_date, class: "form-control", data: { field: 'year', target: "autocomplete.releaseDate" } %>
+        </div>
+        <div class="mb-3">
+          <%= song1_form.label :media_url, "メディアURL", class: "form-label" %>
+          <%= song1_form.text_field :media_url, class: "form-control", id: "media_url_1", data: { target: "autocomplete.mediaUrl" } %>
+          <p>YouTubeに対応しています。</p>
+        </div>
+        <div class="mb-3">
+          <div id="media_player_1"></div>
         </div>
       <% end %>
-      <div class="mb-3">
-        <%= song1_form.label :release_date, "リリース年", class: "form-label" %>
-        <%= song1_form.number_field :release_date, class: "form-control", data: { field: 'year', target: "autocomplete.releaseDate" } %>
-      </div>
-      <div class="mb-3">
-        <%= song1_form.label :media_url, "メディアURL", class: "form-label" %>
-        <%= song1_form.text_field :media_url, class: "form-control", id: "media_url_1", data: { target: "autocomplete.mediaUrl" } %>
-        <p>YouTubeに対応しています。</p>
-      </div>
-      <div class="mb-3">
-        <div id="media_player_1"></div>
-      </div>
-    <% end %>
 
-    <div class="mb-3">
-      <%= f.label :original_song_description, "曲1の説明", class: "form-label" %>
-      <%= f.text_area :original_song_description, class: "form-control" %>
+      <div class="mb-3">
+        <%= f.label :original_song_description, "曲1の説明", class: "form-label" %>
+        <%= f.text_area :original_song_description, class: "form-control" %>
+        <p>注目して欲しいポイントや似てると思ったポイントを記載してください。<br>例) 01:20辺りのメロディ</p>
+      </div>
     </div>
-  </div>
 
-  <h3 class="text-center mb-4">曲情報2</h3>
-  <div data-controller="autocomplete">
-    <%= f.fields_for :similar_song do |song2_form| %>
-      <div class="mb-3">
-        <%= song2_form.label :title, "曲名", class: "form-label" %>
-        <%= song2_form.text_field :title, class: "form-control", data: { action: "input->autocomplete#search", target: "autocomplete.songInput" } %>
-        <ul data-autocomplete-target="songList2" class="autocomplete-list"></ul>
-      </div>
-      <%= song2_form.fields_for :artists do |artist2_form| %>
+    <h3 class="text-center mb-4">曲情報2</h3>
+    <p class="text-center">似てる曲の情報を入力してください。<br>※サンプリングカテゴリーであれば曲情報1で入力した曲をサンプリングしている曲になります。</p>
+    <div data-controller="autocomplete">
+      <%= f.fields_for :similar_song do |song2_form| %>
         <div class="mb-3">
-          <%= artist2_form.label :name, "アーティスト名", class: "form-label" %>
-          <%= artist2_form.text_field :name, class: "form-control", data: { action: "input->autocomplete#searchArtist", target: "autocomplete.artistInput" } %>
-          <ul data-autocomplete-target="artistList2" class="autocomplete-list"></ul>
+          <%= song2_form.label :title, "曲名", class: "form-label" %>
+          <%= song2_form.text_field :title, class: "form-control", data: { action: "input->autocomplete#search", target: "autocomplete.songInput" } %>
+          <ul data-autocomplete-target="songList2" class="autocomplete-list"></ul>
+        </div>
+        <%= song2_form.fields_for :artists do |artist2_form| %>
+          <div class="mb-3">
+            <%= artist2_form.label :name, "アーティスト名", class: "form-label" %>
+            <%= artist2_form.text_field :name, class: "form-control", data: { action: "input->autocomplete#searchArtist", target: "autocomplete.artistInput" } %>
+            <ul data-autocomplete-target="artistList2" class="autocomplete-list"></ul>
+          </div>
+        <% end %>
+        <div class="mb-3">
+          <%= song2_form.label :release_date, "リリース年", class: "form-label" %>
+          <%= song2_form.number_field :release_date, class: "form-control", data: { field: 'year', target: "autocomplete.releaseDate" } %>
+        </div>
+        <div class="mb-3">
+          <%= song2_form.label :media_url, "メディアURL", class: "form-label" %>
+          <%= song2_form.text_field :media_url, class: "form-control", id: "media_url_2", data: { target: "autocomplete.mediaUrl" } %>
+          <p>YouTubeに対応しています。</p>
+        </div>
+        <div class="mb-3">
+          <div id="media_player_2"></div>
         </div>
       <% end %>
-      <div class="mb-3">
-        <%= song2_form.label :release_date, "リリース年", class: "form-label" %>
-        <%= song2_form.number_field :release_date, class: "form-control", data: { field: 'year', target: "autocomplete.releaseDate" } %>
-      </div>
-      <div class="mb-3">
-        <%= song2_form.label :media_url, "メディアURL", class: "form-label" %>
-        <%= song2_form.text_field :media_url, class: "form-control", id: "media_url_2", data: { target: "autocomplete.mediaUrl" } %>
-        <p>YouTubeに対応しています。</p>
-      </div>
-      <div class="mb-3">
-        <div id="media_player_2"></div>
-      </div>
-    <% end %>
 
-    <div class="mb-3">
-      <%= f.label :similar_song_description, "曲2の説明", class: "form-label" %>
-      <%= f.text_area :similar_song_description, class: "form-control" %>
+      <div class="mb-3">
+        <%= f.label :similar_song_description, "曲2の説明", class: "form-label" %>
+        <%= f.text_area :similar_song_description, class: "form-control" %>
+        <p>注目して欲しいポイントや似てると思ったポイントを記載してください。<br>例) 01:20辺りのメロディ</p>
+      </div>
+      <div class="d-flex">
+        <%= button_tag "戻る", type: "button", data: { action: "multi-step-form#previousStep" }, class: "btn btn-primary btn-block" %>
+        <%= f.submit "曲を登録", class: "btn btn-primary btn-block mx-3" %>
+      </div>
     </div>
-  </div>
-
-  <h3 class="text-center mb-4">カテゴリーの情報</h3>
-  <div class="mb-3">
-    <%= f.collection_select :similarity_category_id, @categories, :id, :name, {}, { class: 'form-select' } %>
-  </div>
-  <div class="d-grid">
-    <%= f.submit "保存", class: "btn btn-primary btn-block" %>
   </div>
 <% end %>


### PR DESCRIPTION
# 概要
似てる曲の登録フォームをステップ入力に対応

# 詳細
JavaScript(Stimuls等)を用いて`SongPair`の登録フォーム(`app/views/song_pairs/new.html.erb`)をステップ入力に対応
ステップの流れは以下の通り
1. 注意事項
2. カテゴリー選択
3. 楽曲情報入力

項目3の`曲を登録`ボタンによって楽曲の登録を完了

# その他
- 一部コードの不要なデバッグメッセージなどを削除