### PR TITLE
ログイン状況によって表示を変化させる設定

### DIFF
--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -16,6 +16,6 @@ class UserSessionsController < ApplicationController
 
   def destroy
     logout
-    redirect_to root_path, notice: 'ログインしました。', status: :see_other
+    redirect_to root_path, notice: 'ログアウトしました', status: :see_other
   end
 end

--- a/app/views/home/top.html.erb
+++ b/app/views/home/top.html.erb
@@ -2,17 +2,29 @@
   <h1 class="text-center mb-4">最近登録された曲</h1>
   <div class="mb-4">
     <%= render "shared/song_pair_block", song_pairs: @recent_song_pairs, maximum: 5 %>
-    <div class="more-button d-flex justify-content-center">
-      <%= link_to "もっと見る", recent_path, class: "btn" %>
-    </div>
+    <% if logged_in? %>
+      <div class="more-button d-flex justify-content-center">
+        <%= link_to "もっと見る", recent_path, class: "btn" %>
+      </div>
+    <% else %>
+      <div class="more-button d-flex justify-content-center">
+        <%= link_to "アカウント登録・ログインをしてもっと見る", login_path, class: "btn" %>
+      </div>
+    <% end %>
   </div>
 </div>
 <div>
   <h1 class="text-center mb-4">人気曲</h1>
   <div class="mb-4">
     <%= render "shared/song_pair_block", song_pairs: @popularity_song_pairs, maximum: 5 %>
-    <div class="more-button d-flex justify-content-center">
-      <%= link_to "もっと見る", popular_path, class: "btn" %>
-    </div>
+    <% if logged_in? %>
+      <div class="more-button d-flex justify-content-center">
+        <%= link_to "もっと見る", popular_path, class: "btn" %>
+      </div>
+    <% else %>
+      <div class="more-button d-flex justify-content-center">
+        <%= link_to "アカウント登録・ログインをしてもっと見る", login_path, class: "btn" %>
+      </div>
+    <% end %>
   </div>
 </div>

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -24,7 +24,7 @@
     <div class="header-image text-white">
       <div class="main-area d-flex flex-column align-items-center">
         <h1>『似ている』から始まる曲探し</h1>
-        <%=link_to 'アカウント登録・ログインをして始める', signup_path %>
+        <%=link_to 'アカウント登録・ログインをして始める', login_path %>
         <%= search_form_for @q, url: song_pairs_path, method: :get, class: 'd-flex input-group mb-3' do |f| %>
           <%= f.text_field :original_song_title_or_similar_song_title_or_original_song_artist_list_cont, placeholder: "曲名やアーティスト名から検索", class: "form-control" %>
           <%= f.submit "検索", class: "btn btn-primary" %>

--- a/app/views/song_pairs/_evaluate_button.html.erb
+++ b/app/views/song_pairs/_evaluate_button.html.erb
@@ -7,6 +7,6 @@
     <% end %>
     <p>SIM!数: <%= song_pair.song_pair_evaluations.count %></p>
   <% else %>
-    <%= link_to "アカウント登録・ログインをして似てる曲を評価", signup_path %>
+    <%= link_to "アカウント登録・ログインをして似てる曲を評価", login_path %>
   <% end %>
 </div>

--- a/app/views/song_pairs/index.html.erb
+++ b/app/views/song_pairs/index.html.erb
@@ -4,7 +4,7 @@
     <% if logged_in? %>
       <%= render "shared/sort_with_filter" %>
     <% else %>
-      <%= link_to "アカウント登録・ログインをして並べ替え機能を使う", signup_path %>
+      <p>並べ替え: <%= link_to "アカウント登録・ログインをして並べ替え機能を使う", login_path %></p>
     <% end %>
   </div>
   <div class="mb-4">

--- a/app/views/songs/_song_info.html.erb
+++ b/app/views/songs/_song_info.html.erb
@@ -16,7 +16,7 @@
     <% if logged_in? %>
       <%= link_to "この曲と似てる楽曲を登録", new_song_pair_path(original_song_id: song.id) %>
     <% else %>
-      <%= link_to "アカウント登録・ログインをしてこの曲と似てる楽曲を登録", signup_path %>
+      <%= link_to "アカウント登録・ログインをしてこの曲と似てる楽曲を登録", login_path %>
     <% end %>
   </div>
 </div>

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -8,7 +8,10 @@
     <%= f.label :password, class: "form-label" %>
     <%= f.password_field :password, class: "form-control", placeholder: "パスワードを入力" %>
   </div>
-  <div class="d-grid">
+  <div class="d-grid mb-3">
     <%= f.submit "ログイン", class: "btn btn-primary btn-block" %>
+  </div>
+  <div class="mb-3 text-center">
+    <%= link_to "アカウントを作成する", signup_path %>
   </div>
 <% end %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -16,7 +16,19 @@
     <%= f.label :password_confirmation, class: "form-label" %>
     <%= f.password_field :password_confirmation, class: "form-control" %>
   </div>
-  <div class="d-grid">
+  <div class="d-grid mb-3">
     <%= f.submit "登録", class: "btn btn-primary btn-block" %>
   </div>
+  <div class="mb-3 text-center">
+    <%= link_to "アカウントが既にあるのでログイン", login_path %>
+  </div>
 <% end %>
+<div class="mb-3 d-flex flex-column align-items-center">
+  <h3>アカウント登録をして出来ること</h3>
+  <ul>
+    <li>似てる楽曲のデータベースへの登録</li>
+    <li>楽曲検索の並べ替え機能の使用</li>
+    <li>最近登録された曲や人気曲の一覧表示</li>
+    <li>似てる楽曲への評価</li>
+  </ul>
+</div>


### PR DESCRIPTION
# 概要
ログイン状況により、表示されるリンクなどを変化させる設定を適用

# 詳細
こちら #33 のissueに基づき、ログイン状況に応じて表示されるページやリンクの設定を修正を実行し適用
主な適用部分は以下の通り
- トップページの最近登録された曲と人気曲の一覧ページへのリンク
- 未ログイン時に表示されるヘッダーの`アカウント登録・ログイン`のリンク
- 検索結果ページの並べ替え機能部分
- 楽曲情報ページ(`/songs/:id`)に設置されている楽曲登録フォームへのリンク