### PR TITLE
ページデザインの調整

### DIFF
--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -1,17 +1,4 @@
 // Entry point for your Sass build
-@media (max-width: 768px) {
-    // h3 {
-    //     font-size: 1rem;
-    // }
-    // p {
-    //     font-size: 0.5rem;
-    // }
-    iframe {
-        width: 320px;
-        height: 180px;
-    }
-}
-
 .btn {
     background-color: #FF7171;
     color: #000;
@@ -64,6 +51,10 @@ label {
 iframe {
     width: 100%;
     aspect-ratio: 16 / 9;
+    @media (max-width: 768px) {
+        width: 320px;
+        height: 180px;
+    }
 }
 
 body {

--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -1,14 +1,59 @@
 // Entry point for your Sass build
-@media (max-width: 576px) {
-    h3 {
-        font-size: 1rem;
-    }
-    p {
-        font-size: 0.5rem;
-    }
+@media (max-width: 768px) {
+    // h3 {
+    //     font-size: 1rem;
+    // }
+    // p {
+    //     font-size: 0.5rem;
+    // }
     iframe {
         width: 320px;
         height: 180px;
+    }
+}
+
+.btn {
+    background-color: #FF7171;
+    color: #000;
+}
+
+.btn-primary {
+    --bs-btn-bg: #FF7171;
+    --bs-btn-border-color: #FF7171;
+    --bs-btn-hover-bg: #FF7171;
+    --bs-btn-hover-border-color: #FF7171;
+    --bs-btn-active-bg: #FF7171;
+    --bs-btn-active-border-color: #FF7171;
+    --bs-btn-disabled-bg: #FF7171;
+    --bs-btn-disabled-border-color: #FF7171;
+}
+
+label {
+    white-space: nowrap;
+}
+
+.sort-filter-selectors {
+    display: flex;
+    align-items: center;
+    @media (max-width: 768px) {
+        display: block;
+    }
+}
+
+.sort-select {
+    margin-right: 5px;
+    select {
+        margin-left: 5px;
+    }
+    @media (max-width: 768px) {
+        margin-right: 0;
+        margin-bottom: 5px;
+    }
+}
+
+.filter-select {
+    select {
+        margin-left: 5px;
     }
 }
 
@@ -37,13 +82,6 @@ footer {
 .navbar {
     background-color: #1E1F22;
 }
-
-// .main-area {
-//     margin-left: auto;
-//     margin-right: auto;
-//     width: 60%;
-//     max-width: 1200px;
-// }
 
 .header-image {
     height: 350px;
@@ -78,6 +116,14 @@ footer {
             object-fit: cover;
         }
     }
+    @media (max-width: 768px) {
+        h3 {
+            font-size: 1rem;
+        }
+        p {
+            font-size: 0.5rem;
+        }
+    }
 }
 
 .song-info-block {
@@ -88,8 +134,23 @@ footer {
     p {
         margin-bottom: 0;
     }
+    @media (max-width: 425px) {
+        h3 {
+            font-size: 1em;
+        }
+        h5 {
+            font-size: 1em;
+        }
+        p {
+            font-size: 0.8em;
+        }
+        padding: 1em 1em;
+    }
     .song-info {
-        height: 96px;
+        min-height: 96px;
+        @media (max-width: 425px) {
+            min-height: 70px;
+        }
     }
     .song-jacket-container {
         background-color: #FF7171;
@@ -105,6 +166,10 @@ footer {
             clip-path: inset(45px 105px 45px 105px);
             transform: translate(-50%, -50%) scale(0.4);
             object-fit: cover;
+        }
+        @media (max-width: 425px) {
+            width: 70px;
+            height: 70px;
         }
     }
     .song-description {
@@ -132,9 +197,13 @@ footer {
     width: 30%;
     background-color: #FF7171;
     border-radius: 7px;
-    justify-content: center;
     align-items: center;
+    @media (max-width: 1024px) {
+        width: 100%;
+        white-space: nowrap;
+    }
 }
+
 
 .normal-button {
     margin-left: auto;
@@ -145,6 +214,31 @@ footer {
     border-radius: 7px;
     justify-content: center;
     align-items: center;
+    @media (max-width: 1024px) {
+        width: 100%;
+        white-space: nowrap;
+    }
+}
+
+.evaluate-button {
+    margin-left: auto;
+    margin-right: auto;
+    height: 60px;
+    width: 30%;
+    background-color: #FF7171;
+    border-radius: 7px;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    text-align: center;
+    @media (max-width: 1024px) {
+        width: 100%;
+        white-space: nowrap;
+    }
+    p {
+        margin: 0;
+    }
 }
 
 .pagination {
@@ -163,6 +257,11 @@ footer {
     align-items: center;
     display: flex;
     margin: 0 3px;
+    @media (max-width: 425px) {
+        padding: 0 0.8em;
+        width: auto;
+        white-space: nowrap;
+    }
 }
 
 

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -10,7 +10,7 @@ class UserSessionsController < ApplicationController
       redirect_to root_path, notice: 'ログインしました'
     else
       flash.now[:alert] = 'メールアドレスまたはパスワードが正しくありません'
-      render :new
+      render :new, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -11,7 +11,8 @@ class UsersController < ApplicationController
     if @user.save
       redirect_to login_path, notice: 'ユーザー登録が完了しました'
     else
-      render :new
+      flash.now[:alert] = "入力に誤りがあります"
+      render :new, status: :unprocessable_entity
     end
   end
 

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -20,7 +20,7 @@
       </div>
     </div>
   </div>
-  <% unless current_page?(login_path) || current_page?(signup_path) %>
+  <% unless request.path == login_path || request.path == signup_path %>
     <div class="header-image text-white">
       <div class="main-area d-flex flex-column align-items-center">
         <h1>『似ている』から始まる曲探し</h1>

--- a/app/views/shared/_filter.html.erb
+++ b/app/views/shared/_filter.html.erb
@@ -1,6 +1,6 @@
 <%= form_with method: :get, local: true do %>
-  <div class="d-flex align-items-center">
+  <div class="d-flex align-items-center filter-select">
     <%= label_tag :category, "カテゴリー:" %>
-    <%= select_tag "q[similarity_category_id_eq]", options_from_collection_for_select(SimilarityCategory.all, :id, :name, params.dig(:q, :similarity_category_id_eq)), include_blank: "全て", onchange: "this.form.submit()", class: "mx-2" %>
+    <%= select_tag "q[similarity_category_id_eq]", options_from_collection_for_select(SimilarityCategory.all, :id, :name, params.dig(:q, :similarity_category_id_eq)), include_blank: "全て", onchange: "this.form.submit()", class: "form-select" %>
   </div>
 <% end %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -17,15 +17,13 @@
       </div>
     </div>
   </div>
-  <% unless current_page?(login_path) || current_page?(signup_path) %>
-    <div class="header-image text-white">
-      <div class="main-area d-flex flex-column align-items-center">
-        <h1>『似ている』から始まる曲探し</h1>
-        <%= search_form_for @q, url: song_pairs_path, method: :get, class: 'd-flex input-group mb-3' do |f| %>
-          <%= f.search_field :original_song_title_or_similar_song_title_or_original_song_artist_list_cont, placeholder: "曲名やアーティスト名から検索", class: "form-control" %>
-          <%= f.submit "検索", class: "btn btn-primary" %>
-        <% end %>
-      </div>
+  <div class="header-image text-white">
+    <div class="main-area d-flex flex-column align-items-center">
+      <h1>『似ている』から始まる曲探し</h1>
+      <%= search_form_for @q, url: song_pairs_path, method: :get, class: 'd-flex input-group mb-3' do |f| %>
+        <%= f.search_field :original_song_title_or_similar_song_title_or_original_song_artist_list_cont, placeholder: "曲名やアーティスト名から検索", class: "form-control" %>
+        <%= f.submit "検索", class: "btn btn-primary" %>
+      <% end %>
     </div>
-  <% end %>
+  </div>
 </header>

--- a/app/views/shared/_sort_with_filter.html.erb
+++ b/app/views/shared/_sort_with_filter.html.erb
@@ -1,10 +1,14 @@
 <%= form_with method: :get, local: true do %>
   <%= hidden_field_tag "q[original_song_title_or_similar_song_title_or_original_song_artist_list_cont]", params.dig(:q, :original_song_title_or_similar_song_title_or_original_song_artist_list_cont) %>
-  <div class="d-flex align-items-center">
-    <%= label_tag :sort_by, "並べ替え:" %>
-    <%= select_tag :sort_by, options_for_select([["曲名", "song_title"], ["アーティスト名", "artist_name"], ["登録日", "created_at"]], selected: params[:sort_by] || "created_at"), onchange: "this.form.submit()", class: "mx-2" %>
-    <%= select_tag :order, options_for_select([["降順", "desc"], ["昇順", "asc"]], selected: params[:order] || "desc"), onchange: "this.form.submit()", class: "mx-2" %>
-    <%= label_tag :category, "カテゴリー:" %>
-    <%= select_tag "q[similarity_category_id_eq]", options_from_collection_for_select(SimilarityCategory.all, :id, :name, params.dig(:q, :similarity_category_id_eq)), include_blank: "全て", onchange: "this.form.submit()", class: "mx-2" %>
+  <div class="sort-filter-selectors">
+    <div class="sort-select d-flex align-items-center">
+      <%= label_tag :sort_by, "並べ替え:" %>
+      <%= select_tag :sort_by, options_for_select([["曲名", "song_title"], ["アーティスト名", "artist_name"], ["登録日", "created_at"]], selected: params[:sort_by] || "created_at"), onchange: "this.form.submit()", class: "form-select" %>
+      <%= select_tag :order, options_for_select([["降順", "desc"], ["昇順", "asc"]], selected: params[:order] || "desc"), onchange: "this.form.submit()", class: "form-select" %>
+    </div>
+    <div class="filter-select d-flex align-items-center">
+      <%= label_tag :category, "カテゴリー:" %>
+      <%= select_tag "q[similarity_category_id_eq]", options_from_collection_for_select(SimilarityCategory.all, :id, :name, params.dig(:q, :similarity_category_id_eq)), include_blank: "全て", onchange: "this.form.submit()", class: "form-select" %>
+    </div>
   </div>
 <% end %>

--- a/app/views/song_pairs/_evaluate_button.html.erb
+++ b/app/views/song_pairs/_evaluate_button.html.erb
@@ -1,11 +1,13 @@
-<div class="normal-button text-center">
+<div class="evaluate-button">
   <% if logged_in? %>
-    <% if current_user.song_pair_evaluated?(song_pair) %>
-      <%= link_to "SIM!を取り消す", song_pair_evaluation_path(current_user.song_pair_evaluations.find_by(song_pair_id: song_pair.id)), data: { turbo_method: :delete }%>
-    <% else %>
-      <%= link_to "SIM!する", song_pair_evaluations_path(song_pair_id: song_pair.id), data: { turbo_method: :post } %>
-    <% end %>
-    <p>SIM!数: <%= song_pair.song_pair_evaluations.count %></p>
+    <div>
+      <% if current_user.song_pair_evaluated?(song_pair) %>
+        <%= link_to "SIM!を取り消す", song_pair_evaluation_path(current_user.song_pair_evaluations.find_by(song_pair_id: song_pair.id)), data: { turbo_method: :delete }%>
+      <% else %>
+        <%= link_to "SIM!する", song_pair_evaluations_path(song_pair_id: song_pair.id), data: { turbo_method: :post } %>
+      <% end %>
+      <p>SIM!数: <%= song_pair.song_pair_evaluations.count %></p>
+    </div>
   <% else %>
     <%= link_to "アカウント登録・ログインをして似てる曲を評価", login_path %>
   <% end %>

--- a/app/views/song_pairs/index.html.erb
+++ b/app/views/song_pairs/index.html.erb
@@ -4,7 +4,10 @@
     <% if logged_in? %>
       <%= render "shared/sort_with_filter" %>
     <% else %>
-      <p>並べ替え: <%= link_to "アカウント登録・ログインをして並べ替え機能を使う", login_path %></p>
+      <div class="text-center">
+        <p>並べ替え:</p>
+        <p><%= link_to "アカウント登録・ログインをして並べ替え機能を使う", login_path %></p>
+      </div>
     <% end %>
   </div>
   <div class="mb-4">

--- a/app/views/song_pairs/new.html.erb
+++ b/app/views/song_pairs/new.html.erb
@@ -9,7 +9,7 @@
       楽曲やアーティストに対する悪意のある書き込み等は残すことのないようお願いします。<br>
       誰が見ても純粋に「あ！似てる！面白い！」と思えるようなコンテンツにしていきましょう。</p>
     </div>
-    <div>
+    <div class="d-flex justify-content-center">
       <%= button_tag "次に進む", type: "button", data: { action: "multi-step-form#nextStep" }, class: "btn btn-primary btn-block" %>
     </div>
   </div>
@@ -38,7 +38,7 @@
       <p>サンプリングのされ方は様々で『ボーカル部分だけ使われている』、『ドラム部分だけ使われている』、『イントロ部分だけ使われている』など既存の楽曲音源を部分的に使用することでただ楽器を演奏したり、歌うだけでは出来ない新しい表現を生み出すことができます。</p>
       <p>イメージしづらい場合はサンプリングカテゴリーで登録されている楽曲を実際に参考にしてみてください。</p>
     </div>
-    <div>
+    <div class="d-flex justify-content-center">
       <%= button_tag "次に進む", type: "button", data: { action: "multi-step-form#nextStep" }, class: "btn btn-primary btn-block" %>
     </div>
   </div>
@@ -127,7 +127,7 @@
         <%= f.text_area :similar_song_description, class: "form-control" %>
         <p>注目して欲しいポイントや似てると思ったポイントを記載してください。<br>例) 01:20辺りのメロディ</p>
       </div>
-      <div class="d-flex">
+      <div class="d-flex justify-content-center">
         <%= button_tag "戻る", type: "button", data: { action: "multi-step-form#previousStep" }, class: "btn btn-primary btn-block" %>
         <%= f.submit "曲を登録", class: "btn btn-primary btn-block mx-3" %>
       </div>

--- a/app/views/songs/_song_info.html.erb
+++ b/app/views/songs/_song_info.html.erb
@@ -16,7 +16,10 @@
     <% if logged_in? %>
       <%= link_to "この曲と似てる楽曲を登録", new_song_pair_path(original_song_id: song.id) %>
     <% else %>
-      <%= link_to "アカウント登録・ログインをしてこの曲と似てる楽曲を登録", login_path %>
+      <%= link_to login_path, class: "text-center" do %>
+        <p>アカウント登録・ログインをして</p>
+        <p>この曲と似てる楽曲を登録</p>
+      <% end %>
     <% end %>
   </div>
 </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,6 +10,7 @@ module SimilarSongs
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.0
+    config.i18n.default_locale = :ja
 
     # Configuration for the application, engines, and railties goes here.
     #

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -3,7 +3,7 @@
 Kaminari.configure do |config|
   config.default_per_page = 5
   # config.max_per_page = nil
-  # config.window = 4
+  config.window = 1
   # config.outer_window = 0
   # config.left = 0
   # config.right = 0

--- a/config/locales/kaminari.ja.yml
+++ b/config/locales/kaminari.ja.yml
@@ -1,0 +1,8 @@
+ja:
+  views:
+    pagination:
+      first: '<<'
+      last: '>>'
+      previous: '<'
+      next: '>'
+      truncate: '...'


### PR DESCRIPTION
# 概要
ページデザインの基本的な部分を調整

# 詳細
こちら #17 のissueに基づいて以下の項目を中心にページデザインを調整
- ヘッダー、フッターのデザイン
- トップページのデザイン
- フォント
- hタグのデザイン
- 入力フォーム関連のデザイン
- アカウント新規登録ページ
- ログインページ
- 楽曲登録ページ
- 最近登録された曲一覧ページ
- 楽曲ページ
- 似てる・サンプリング曲の組み合わせページ
- 検索バー
- 検索結果ページ