### PR TITLE
MVPレビュー向けの修正

### DIFF
--- a/app/controllers/song_pairs_controller.rb
+++ b/app/controllers/song_pairs_controller.rb
@@ -64,7 +64,7 @@ class SongPairsController < ApplicationController
     # SongPairとそれに関連するデータの保存に失敗した場合にエラーを検出
     ActiveRecord::Base.transaction do
       # 関連データのバリデーションを事前チェック
-      # @song_pair.validate_associated_songs_and_artists
+      @song_pair.validate_associated_songs_and_artists
 
       # 曲1の保存
       original_song = @song_pair.add_song(song_pair_params[:original_song_attributes])

--- a/app/javascript/media_widget.js
+++ b/app/javascript/media_widget.js
@@ -21,11 +21,15 @@ document.addEventListener("turbo:load", () => {
 
       // URLの手動入力を監視
       mediaUrlField.addEventListener('input', () => {
+        const normalizedUrl = normalizeYouTubeUrl(mediaUrlField.value);
+        mediaUrlField.value = normalizedUrl;
         updateMediaPlayer(mediaUrlField.value, mediaPlayer)
       });
 
       // URLの自動入力を監視(オートコンプリート等での自動入力対応)
       mediaUrlField.addEventListener('change', () => {
+        const normalizedUrl = normalizeYouTubeUrl(mediaUrlField.value);
+        mediaUrlField.value = normalizedUrl;
         updateMediaPlayer(mediaUrlField.value, mediaPlayer)
       });
 
@@ -34,6 +38,8 @@ document.addEventListener("turbo:load", () => {
       setInterval(() => {
         if (mediaUrlField.value !== previousValue) {
           previousValue = mediaUrlField.value;
+          const normalizedUrl = normalizeYouTubeUrl(mediaUrlField.value);
+          mediaUrlField.value = normalizedUrl;
           updateMediaPlayer(mediaUrlField.value, mediaPlayer)
         }
       }, 1000);  // 1秒ごとにチェック
@@ -53,6 +59,15 @@ document.addEventListener("turbo:load", () => {
     } else {
       playerElement.innerHTML = '';
     }
+  }
+
+  // YouTubeのURLをシンプルな形式に変換する処理
+  function normalizeYouTubeUrl(url) {
+    const mediaId = extractMediaId(url);
+    if (mediaId) {
+      return `https://www.youtube.com/watch?v=${mediaId}`;
+    }
+    return url;
   }
 
   // 動画IDを抽出する関数

--- a/app/models/song.rb
+++ b/app/models/song.rb
@@ -83,7 +83,7 @@ class Song < ApplicationRecord
   def media_url_format
     # URLが入力されており、形式が正しい場合は処理を終了
     return if media_url.present? && media_url.match?(%r{\A(https://www\.youtube\.com/watch\?v=|https://youtu\.be/)([\w-]{11})\z})
-    
+
     errors.add(:media_url, I18n.t('errors.messages.invalid_media_url'))
   end
 end

--- a/app/models/song.rb
+++ b/app/models/song.rb
@@ -48,23 +48,12 @@ class Song < ApplicationRecord
 
   # ransackでの検索対象カラムを設定
   def self.ransackable_attributes(_auth_object = nil)
-    ["title", "artist_list"]
+    ["title"]
   end
 
   # ransackで関連するデータを検索対象にできるように設定
   def self.ransackable_associations(_auth_object = nil)
     ["artists"]
-  end
-
-  # ransackでartist_listからアーティスト一覧を取得出来るように設定
-  ransacker :artist_list do
-    Arel.sql <<-SQL.squish
-    (SELECT GROUP_CONCAT(artists.name SEPARATOR ', ')
-    FROM song_artists
-    JOIN artists ON song_artists.artist_id = artists.id
-    WHERE song_artists.song_id = songs.id
-    GROUP BY song_artists.song_id)
-    SQL
   end
 
   private

--- a/app/models/song.rb
+++ b/app/models/song.rb
@@ -5,8 +5,8 @@ class Song < ApplicationRecord
   has_many :similar_song_pairs, class_name: "SongPair", foreign_key: :similar_song_id, inverse_of: :similar_song, dependent: :nullify
 
   validates :title, presence: true, length: { maximum: 255 }
-  validates :media_url, presence: true, format: { with: %r{\A(https://www\.youtube\.com/watch\?v=|https://youtu\.be/)[\w-]+\z}, message: "は有効なYouTubeリンクである必要があります" }
-
+  # validates :media_url, presence: true, format: { with: %r{\A(https://www\.youtube\.com/watch\?v=|https://youtu\.be/)[\w-]+\z} }
+  validate :media_url_format
   validate :release_date_check
 
   accepts_nested_attributes_for :artists
@@ -88,5 +88,13 @@ class Song < ApplicationRecord
     reg_exp = %r{^.*(youtu.be/|v/|u/\w/|embed/|watch\?v=|&v=)([^#\&\?]*).*}
     match = url.match(reg_exp)
     match[2] if match && match[2].length == 11
+  end
+
+  # メディアURLの形式と空欄であるかどうかをチェック
+  def media_url_format
+    # URLが入力されており、形式が正しい場合は処理を終了
+    return if media_url.present? && media_url.match?(%r{\A(https://www\.youtube\.com/watch\?v=|https://youtu\.be/)([\w-]{11})\z})
+    
+    errors.add(:media_url, I18n.t('errors.messages.invalid_media_url'))
   end
 end

--- a/app/models/song_pair.rb
+++ b/app/models/song_pair.rb
@@ -14,9 +14,20 @@ class SongPair < ApplicationRecord
 
   # 引数で受け取った楽曲・アーティスト情報を記録する処理
   def add_song(song_attributes)
-    # 曲の保存
-    song = Song.find_or_initialize_by(title: song_attributes[:title])
-    song.update!(song_attributes.except(:artists_attributes))
+    # 既存のデータとして存在するかチェック
+    existing_song = Song.joins(:artists).where(
+      title: song_attributes[:title],
+      artists: { name: song_attributes[:artists_attributes].values.map { |a| a[:name] } }
+    ).first
+
+    # 既存のデータがあればそちらを、なければ新規でデータを作成
+    song = existing_song || Song.new(title: song_attributes[:title], release_date: song_attributes[:release_date])
+
+    # 新規作成の場合は楽曲データを保存
+    if song.new_record?
+      song.assign_attributes(song_attributes.except(:artists_attributes))
+      song.save!
+    end
 
     # アーティストの保存
     song_attributes[:artists_attributes].each_value do |artist_attributes|
@@ -44,5 +55,32 @@ class SongPair < ApplicationRecord
 
     # Ahoyで記録された閲覧記録から該当するURLページへの閲覧(アクセス)数を取得
     Ahoy::Visit.where(landing_page: url).count
+  end
+
+  # カテゴリー名をI18nによる翻訳を行い出力
+  def similarity_category_name
+    I18n.t("similarity_category.#{similarity_category.name}")
+  end
+  
+  # 関連するモデルも含めた全バリデーションチェック
+  def validate_associated_songs_and_artists
+    validate_songs_and_artists(original_song, "曲情報1", :original_song_description)
+    validate_songs_and_artists(similar_song, "曲情報2", :similar_song_description)
+    
+    raise ActiveRecord::RecordInvalid.new(self) if errors.any?
+  end
+  
+  private
+
+  # 楽曲とそのアーティストに関するバリデーションチェックを行う処理
+  def validate_songs_and_artists(song, song_label, song_description)
+    unless song.valid?
+      song.errors.full_messages.uniq.each do |message|
+        error_message = "#{song_label}の#{message}"
+        errors.add(:base, error_message) unless errors[:base].include?(error_message)
+      end
+    end
+
+    errors.add(song_description, "#{song_label}#{I18n.t("errors.messages.blank_song_description")}") if send(song_description).blank?
   end
 end

--- a/app/models/song_pair.rb
+++ b/app/models/song_pair.rb
@@ -14,10 +14,10 @@ class SongPair < ApplicationRecord
 
   # 引数で受け取った楽曲・アーティスト情報を記録する処理
   def add_song(song_attributes)
-    # 既存のデータとして存在するかチェック
+    # 既存のデータとして存在するかチェック(条件は曲名とアーティスト)
     existing_song = Song.joins(:artists).where(
       title: song_attributes[:title],
-      artists: { name: song_attributes[:artists_attributes].values.map { |a| a[:name] } }
+      artists: { name: song_attributes[:artists_attributes].values.pluck(:name) }
     ).first
 
     # 既存のデータがあればそちらを、なければ新規でデータを作成
@@ -83,16 +83,18 @@ class SongPair < ApplicationRecord
   def similarity_category_name
     I18n.t("similarity_category.#{similarity_category.name}")
   end
-  
+
   # 関連するモデルも含めた全バリデーションチェック
   def validate_associated_songs_and_artists
     validate_songs_and_artists(original_song, "曲情報1", :original_song_description)
     validate_songs_and_artists(similar_song, "曲情報2", :similar_song_description)
-    
-    # エラーが発生した場合は保存処理の中止
+
+    # エラーが発生した場合は保存処理の中止(rubocopの指摘を一部除外)
+    # rubocop:disable Style/RaiseArgs
     raise ActiveRecord::RecordInvalid.new(self) if errors.any?
+    # rubocop:enable Style/RaiseArgs
   end
-  
+
   private
 
   # 楽曲とそのアーティストに関するバリデーションチェックを行う処理
@@ -106,6 +108,6 @@ class SongPair < ApplicationRecord
     end
 
     # 楽曲説明のチェック
-    errors.add(song_description, "#{song_label}#{I18n.t("errors.messages.blank_song_description")}") if send(song_description).blank?
+    errors.add(song_description, "#{song_label}#{I18n.t('errors.messages.blank_song_description')}") if send(song_description).blank?
   end
 end

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -26,7 +26,7 @@
         <h1>『似ている』から始まる曲探し</h1>
         <%=link_to 'アカウント登録・ログインをして始める', login_path %>
         <%= search_form_for @q, url: song_pairs_path, method: :get, class: 'd-flex input-group mb-3' do |f| %>
-          <%= f.text_field :original_song_title_or_similar_song_title_or_original_song_artist_list_cont, placeholder: "曲名やアーティスト名から検索", class: "form-control" %>
+          <%= f.search_field :original_song_title_or_similar_song_title_or_original_song_artist_list_or_similar_song_artist_list_cont, placeholder: "曲名やアーティスト名から検索", class: "form-control" %>
           <%= f.submit "検索", class: "btn btn-primary" %>
         <% end %>
       </div>

--- a/app/views/shared/_filter.html.erb
+++ b/app/views/shared/_filter.html.erb
@@ -1,6 +1,6 @@
 <%= form_with method: :get, local: true do %>
   <div class="d-flex align-items-center filter-select">
     <%= label_tag :category, "カテゴリー:" %>
-    <%= select_tag "q[similarity_category_id_eq]", options_from_collection_for_select(SimilarityCategory.all, :id, :name, params.dig(:q, :similarity_category_id_eq)), include_blank: "全て", onchange: "this.form.submit()", class: "form-select" %>
+    <%= select_tag "q[similarity_category_id_eq]", options_from_collection_for_select(categories, :id, :name, params.dig(:q, :similarity_category_id_eq)), include_blank: "全て", onchange: "this.form.submit()", class: "form-select" %>
   </div>
 <% end %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -21,7 +21,7 @@
     <div class="main-area d-flex flex-column align-items-center">
       <h1>『似ている』から始まる曲探し</h1>
       <%= search_form_for @q, url: song_pairs_path, method: :get, class: 'd-flex input-group mb-3' do |f| %>
-        <%= f.search_field :original_song_title_or_similar_song_title_or_original_song_artist_list_cont, placeholder: "曲名やアーティスト名から検索", class: "form-control" %>
+        <%= f.search_field :original_song_title_or_similar_song_title_or_original_song_artist_list_or_similar_song_artist_list_cont, placeholder: "曲名やアーティスト名から検索", class: "form-control" %>
         <%= f.submit "検索", class: "btn btn-primary" %>
       <% end %>
     </div>

--- a/app/views/shared/_song_pair_block.html.erb
+++ b/app/views/shared/_song_pair_block.html.erb
@@ -8,7 +8,7 @@
       <p class="mb-0">→似てる曲: <%= song_pair.similar_song.artist_list %> - <%= song_pair.similar_song.title %></p>
     </div>
     <div class="song-category ms-auto">
-      <%= link_to "カテゴリー: #{song_pair.similarity_category.name}", "#"%>
+      <%= link_to "カテゴリー: #{song_pair.similarity_category_name}", "#"%>
     </div>
   </div>
 <% end %>

--- a/app/views/shared/_sort_with_filter.html.erb
+++ b/app/views/shared/_sort_with_filter.html.erb
@@ -8,7 +8,7 @@
     </div>
     <div class="filter-select d-flex align-items-center">
       <%= label_tag :category, "カテゴリー:" %>
-      <%= select_tag "q[similarity_category_id_eq]", options_from_collection_for_select(SimilarityCategory.all, :id, :name, params.dig(:q, :similarity_category_id_eq)), include_blank: "全て", onchange: "this.form.submit()", class: "form-select" %>
+      <%= select_tag "q[similarity_category_id_eq]", options_from_collection_for_select(categories, :id, :name, params.dig(:q, :similarity_category_id_eq)), include_blank: "全て", onchange: "this.form.submit()", class: "form-select" %>
     </div>
   </div>
 <% end %>

--- a/app/views/shared/_sort_with_filter.html.erb
+++ b/app/views/shared/_sort_with_filter.html.erb
@@ -1,5 +1,5 @@
 <%= form_with method: :get, local: true do %>
-  <%= hidden_field_tag "q[original_song_title_or_similar_song_title_or_original_song_artist_list_cont]", params.dig(:q, :original_song_title_or_similar_song_title_or_original_song_artist_list_cont) %>
+  <%= hidden_field_tag "q[original_song_title_or_similar_song_title_or_original_song_artist_list_or_similar_song_artist_list_cont]", params.dig(:q, :original_song_title_or_similar_song_title_or_original_song_artist_list_or_similar_song_artist_list_cont) %>
   <div class="sort-filter-selectors">
     <div class="sort-select d-flex align-items-center">
       <%= label_tag :sort_by, "並べ替え:" %>

--- a/app/views/song_pairs/index.html.erb
+++ b/app/views/song_pairs/index.html.erb
@@ -2,7 +2,7 @@
   <h1 class="text-center mb-4">検索結果</h1>
   <div class="d-flex justify-content-center mb-4">
     <% if logged_in? %>
-      <%= render "shared/sort_with_filter" %>
+      <%= render "shared/sort_with_filter", categories: @categories %>
     <% else %>
       <div class="text-center">
         <p>並べ替え:</p>

--- a/app/views/song_pairs/new.html.erb
+++ b/app/views/song_pairs/new.html.erb
@@ -73,12 +73,14 @@
         <% end %>
         <div class="mb-3">
           <%= song1_form.label :release_date, "リリース年", class: "form-label" %>
-          <%= song1_form.number_field :release_date, class: "form-control", data: { field: 'year', target: "autocomplete.releaseDate" } %>
+          <%= song1_form.select :release_date, options_for_select((1870..Date.today.year).to_a.reverse.map(&:to_s), "2000"), {}, class: "form-select", data: { field: 'year', target: "autocomplete.releaseDate" } %>
         </div>
         <div class="mb-3">
           <%= song1_form.label :media_url, "メディアURL", class: "form-label" %>
           <%= song1_form.text_field :media_url, class: "form-control", id: "media_url_1", data: { target: "autocomplete.mediaUrl" } %>
-          <p>YouTubeに対応しています。</p>
+          <p>YouTubeのURLに対応しています。<br>
+          ※実在するコンテンツや正しい形式のURLでないと保存できません。
+          <br>正しいURLが入力された場合はページ上に動画ウィジェットが表示されて動画を確認できます。</p>
         </div>
         <div class="mb-3">
           <div id="media_player_1"></div>
@@ -110,12 +112,14 @@
         <% end %>
         <div class="mb-3">
           <%= song2_form.label :release_date, "リリース年", class: "form-label" %>
-          <%= song2_form.number_field :release_date, class: "form-control", data: { field: 'year', target: "autocomplete.releaseDate" } %>
+          <%= song2_form.select :release_date, options_for_select((1870..Date.today.year).to_a.reverse.map(&:to_s), "2000"), {}, class: "form-select", data: { field: 'year', target: "autocomplete.releaseDate" } %>
         </div>
         <div class="mb-3">
           <%= song2_form.label :media_url, "メディアURL", class: "form-label" %>
           <%= song2_form.text_field :media_url, class: "form-control", id: "media_url_2", data: { target: "autocomplete.mediaUrl" } %>
-          <p>YouTubeに対応しています。</p>
+          <p>YouTubeのURLに対応しています。<br>
+          ※実在するコンテンツや正しい形式のURLでないと保存できません。
+          <br>正しいURLが入力された場合はページ上に動画ウィジェットが表示されて動画を確認できます。</p>
         </div>
         <div class="mb-3">
           <div id="media_player_2"></div>

--- a/app/views/song_pairs/new.html.erb
+++ b/app/views/song_pairs/new.html.erb
@@ -73,14 +73,12 @@
         <% end %>
         <div class="mb-3">
           <%= song1_form.label :release_date, "リリース年", class: "form-label" %>
-          <%= song1_form.select :release_date, options_for_select((1870..Date.today.year).to_a.reverse.map(&:to_s), "2000"), {}, class: "form-select", data: { field: 'year', target: "autocomplete.releaseDate" } %>
+          <%= song1_form.select :release_date, options_for_select((1870..Date.today.year).to_a.reverse.map(&:to_s), song1_form.object.release_date), {}, class: "form-select", data: { field: 'year', target: "autocomplete.releaseDate" } %>
         </div>
         <div class="mb-3">
           <%= song1_form.label :media_url, "メディアURL", class: "form-label" %>
           <%= song1_form.text_field :media_url, class: "form-control", id: "media_url_1", data: { target: "autocomplete.mediaUrl" } %>
-          <p>YouTubeのURLに対応しています。<br>
-          ※実在するコンテンツや正しい形式のURLでないと保存できません。
-          <br>正しいURLが入力された場合はページ上に動画ウィジェットが表示されて動画を確認できます。</p>
+          <p>YouTubeのURLに対応しています。</p>
         </div>
         <div class="mb-3">
           <div id="media_player_1"></div>
@@ -112,14 +110,12 @@
         <% end %>
         <div class="mb-3">
           <%= song2_form.label :release_date, "リリース年", class: "form-label" %>
-          <%= song2_form.select :release_date, options_for_select((1870..Date.today.year).to_a.reverse.map(&:to_s), "2000"), {}, class: "form-select", data: { field: 'year', target: "autocomplete.releaseDate" } %>
+          <%= song2_form.select :release_date, options_for_select((1870..Date.today.year).to_a.reverse.map(&:to_s), song2_form.object.release_date), {}, class: "form-select", data: { field: 'year', target: "autocomplete.releaseDate" } %>
         </div>
         <div class="mb-3">
           <%= song2_form.label :media_url, "メディアURL", class: "form-label" %>
           <%= song2_form.text_field :media_url, class: "form-control", id: "media_url_2", data: { target: "autocomplete.mediaUrl" } %>
-          <p>YouTubeのURLに対応しています。<br>
-          ※実在するコンテンツや正しい形式のURLでないと保存できません。
-          <br>正しいURLが入力された場合はページ上に動画ウィジェットが表示されて動画を確認できます。</p>
+          <p>YouTubeのURLに対応しています。</p>
         </div>
         <div class="mb-3">
           <div id="media_player_2"></div>

--- a/app/views/song_pairs/popularity_page.html.erb
+++ b/app/views/song_pairs/popularity_page.html.erb
@@ -1,7 +1,7 @@
 <div>
   <h1 class="text-center mb-4">人気曲</h1>
   <div class="d-flex justify-content-center mb-4">
-    <%= render "shared/filter" %>
+    <%= render "shared/filter", categories: @categories %>
   </div>
   <div class="mb-4">
     <%= render "shared/song_pair_block", song_pairs: @song_pairs %>

--- a/app/views/song_pairs/recent_page.html.erb
+++ b/app/views/song_pairs/recent_page.html.erb
@@ -1,7 +1,7 @@
 <div>
   <h1 class="text-center mb-4">最近登録された曲</h1>
   <div class="d-flex justify-content-center mb-4">
-    <%= render "shared/filter" %>
+    <%= render "shared/filter", categories: @categories %>
   </div>
   <div class="mb-4">
     <%= render "shared/song_pair_block", song_pairs: @song_pairs %>

--- a/app/views/song_pairs/show.html.erb
+++ b/app/views/song_pairs/show.html.erb
@@ -9,7 +9,7 @@
   <% if @song_pair.similarity_category.id == 3 %>
     <h2 class="text-center mb-4">↓サンプリングされてる</h2>
   <% else %>
-    <h2 class="text-center mb-4">↓似てる: <%= @song_pair.similarity_category.name %></h2>
+    <h2 class="text-center mb-4">↓似てる: <%= @song_pair.similarity_category_name %></h2>
   <% end %>
   
   <%= render 'song_info', song: @song_pair.similar_song, song_description: @song_pair.similar_song_description %>

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -1,15 +1,15 @@
 <h1 class="text-center mb-4">ログイン</h1>
 <%= form_with url: login_path, local: true, class: "form-signin" do |f| %>
   <div class="mb-3">
-    <%= f.label :email, class: "form-label" %>
+    <%= f.label :email, t('views.user_sessions.email'), class: "form-label" %>
     <%= f.email_field :email, class: "form-control", placeholder: "メールアドレスを入力", autofocus: true %>
   </div>
   <div class="mb-3">
-    <%= f.label :password, class: "form-label" %>
+    <%= f.label :password, t('views.user_sessions.password'), class: "form-label" %>
     <%= f.password_field :password, class: "form-control", placeholder: "パスワードを入力" %>
   </div>
   <div class="d-grid mb-3">
-    <%= f.submit "ログイン", class: "btn btn-primary btn-block" %>
+    <%= f.submit t('views.user_sessions.submit'), class: "btn btn-primary btn-block" %>
   </div>
   <div class="mb-3 text-center">
     <%= link_to "アカウントを作成する", signup_path %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,7 @@ module SimilarSongs
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.0
     config.i18n.default_locale = :ja
+    config.i18n.available_locales = [:en, :ja]
 
     # Configuration for the application, engines, and railties goes here.
     #

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,49 @@
+ja:
+  views:
+    user_sessions:
+      email: "メールアドレス"
+      password: "パスワード"
+      submit: "ログイン"
+  similarity_category:
+    melody: "メロディー"
+    style: "ジャンル・スタイル"
+    sampling: "サンプリング"
+  activerecord:
+    models:
+      artist: "アーティスト"
+      similarity_category: "カテゴリー"
+      song_artist: "楽曲のアーティスト"
+      song_pair_evaluation: "SIM!"
+      song_pair: "似てる曲の組み合わせ"
+      song: "楽曲"
+      user: "ユーザー"
+    attributes:
+      artist:
+        name: "アーティスト名"
+      similarity_category:
+        name: "カテゴリー名"
+      song_pair:
+        original_song_description: "曲1の説明"
+        similar_song_description: "曲2の説明"
+      song:
+        title: "曲名"
+        release_date: "リリース年"
+        media_url: "メディアURL"
+      user:
+        name: "ユーザー名"
+        email: "メールアドレス"
+        password: "パスワード"
+        password_confirmation: "パスワードの再確認"
+    errors:
+      messages:
+        blank: "%{attribute}が入力されていません"
+      models:
+        song_pair:
+          attributes:
+            original_song_id:
+              taken: "既に存在している曲の組み合わせです"
+  errors:
+    format: "%{message}"
+    messages:
+      invalid_media_url: "メディアURLが入力されていないか、形式が正しくありません"
+      blank_song_description: "の説明が入力されていません"


### PR DESCRIPTION
# 概要
MVPレビュー https://github.com/8kjapon/similar-songs/issues/72 で添削のあった楽曲登録フォームの調整

# 詳細
MVPレビューの添削ポイントである楽曲登録フォームの以下の点を調整
## リリース年の入力方式と初期値
- リリース年の入力方式をプルダウンメニューに変更
- 初期値を現在の年に設定

## YouTubeのリンクの取り扱いについて
- 対応していなかったURL形式を把握
- 意図しない形式のURLが入力された場合は一般的なYouTubeのURL(`https://www.youtube.com/watch?v=xxxxxxxxxxx`)に自動で整形する機能を実装

## エラーメッセージの調整
- エラーメッセージをi18nによる日本語化
- 各エラーメッセージを具体的な内容に設定