### PR TITLE
font-awesomeの変更

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -93,6 +93,4 @@ gem "ahoy_matey"
 
 gem "kaminari"
 
-gem "font-awesome-sass", "~> 6.5.2"
-
 gem "meta-tags"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,9 +115,6 @@ GEM
       logger
     faraday-net_http (3.3.0)
       net-http
-    ffi (1.17.0-x86_64-linux-gnu)
-    font-awesome-sass (6.5.2)
-      sassc (~> 2.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
     hashie (5.0.0)
@@ -284,8 +281,6 @@ GEM
     ruby-progressbar (1.13.0)
     rubyzip (2.3.2)
     safely_block (0.4.1)
-    sassc (2.4.0)
-      ffi (~> 1.9)
     selenium-webdriver (4.25.0)
       base64 (~> 0.2)
       logger (~> 1.4)
@@ -360,7 +355,6 @@ DEPENDENCIES
   cssbundling-rails
   debug
   dotenv-rails
-  font-awesome-sass (~> 6.5.2)
   jbuilder
   jsbundling-rails
   kaminari

--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -1,6 +1,6 @@
 // Entry point for your Sass build
-$fa-font-path: "/assets/font-awesome";
-@import "font-awesome";
+@import "@fortawesome/fontawesome-free/css/all.css";
+
 
 .btn {
     background-color: #FF7171;

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -10,3 +10,4 @@ Rails.application.config.assets.version = "1.0"
 # application.js, application.css, and all non-JS/CSS in the app/assets
 # folder are already added.
 # Rails.application.config.assets.precompile += %w( admin.js admin.css )
+Rails.application.config.assets.paths << Rails.root.join('node_modules')

--- a/package.json
+++ b/package.json
@@ -6,9 +6,10 @@
   },
   "scripts": {
     "build": "esbuild app/javascript/*.* --bundle --sourcemap --format=esm --outdir=app/assets/builds --public-path=/assets",
-    "build:css": "sass ./app/assets/stylesheets/application.sass.scss:./app/assets/builds/application.css --no-source-map --load-path=node_modules --load-path=/usr/local/bundle/gems/font-awesome-sass-6.5.2/assets/stylesheets"
+    "build:css": "sass ./app/assets/stylesheets/application.sass.scss:./app/assets/builds/application.css --no-source-map --load-path=node_modules"
   },
   "dependencies": {
+    "@fortawesome/fontawesome-free": "^6.7.1",
     "@hotwired/stimulus": "^3.2.2",
     "@hotwired/turbo-rails": "^8.0.10",
     "sass": "^1.79.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -122,6 +122,11 @@
   resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.24.0.tgz#168ab1c7e1c318b922637fad8f339d48b01e1244"
   integrity sha512-7IAFPrjSQIJrGsK6flwg7NFmwBoSTyF3rl7If0hNUFQU4ilTsEPL6GuMuU9BfIWVVGuRnuIidkSMC+c0Otu8IA==
 
+"@fortawesome/fontawesome-free@^6.7.1":
+  version "6.7.1"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-free/-/fontawesome-free-6.7.1.tgz#160a48730d533ec77578ed0141661a8f0150a71d"
+  integrity sha512-ALIk/MOh5gYe1TG/ieS5mVUsk7VUIJTJKPMK9rFFqOgfp0Q3d5QiBXbcOMwUvs37fyZVCz46YjOE6IFeOAXCHA==
+
 "@hotwired/stimulus@^3.2.2":
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/@hotwired/stimulus/-/stimulus-3.2.2.tgz#071aab59c600fed95b97939e605ff261a4251608"


### PR DESCRIPTION
# 概要
font-awesome-sassの挙動に問題があった為、Node.js版のfont-awesomeに移行

# 詳細
`gem "font-awesome-sass"`からNode.jsの`@fortawesome/fontawesome-free`へ移行
移行に伴いスタイルシートやアセット関連の設定を修正