### PR TITLE
マイページの追加

### DIFF
--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -308,3 +308,25 @@ footer {
 .hidden {
     display: none;
 }
+
+.user-info {
+    background-color: #fff;
+    color: #000;
+    border-radius: 7px;
+    padding: 1em 2em;
+    p {
+        margin-bottom: 0;
+    }
+    @media (max-width: 425px) {
+        p {
+            font-size: 0.8em;
+        }
+        padding: 1em 1em;
+    }
+    .song-info {
+        min-height: 96px;
+        @media (max-width: 425px) {
+            min-height: 70px;
+        }
+    }
+}

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -16,6 +16,11 @@ class UsersController < ApplicationController
     end
   end
 
+  def show
+    @user = current_user
+    @song_pairs = SongPair.includes(:similarity_category, original_song: :artists, similar_song: :artists).where(user_id: @user.id)
+  end
+
   private
 
   def user_params

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -11,6 +11,9 @@
             <%= link_to '楽曲を登録', new_song_pair_path, class: 'nav-link' %>
           </li>
           <li class="nav-item">
+            <%= link_to 'マイページ', mypage_path, class: 'nav-link' %>
+          </li>
+          <li class="nav-item">
             <%= link_to 'ログアウト', logout_path, class: 'nav-link', data: { turbo_method: :delete } %>
           </li>
         </ul>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,0 +1,7 @@
+<% set_meta_tags(title: "マイページ", og: { title: "マイページ" }) %>
+<h1 class="text-center mb-4">マイページ</h1>
+<div class="mb-4 user-info">
+  <p>ユーザー名: <%= @user.name %></p>
+  <p>登録日: <%= @user.created_at.strftime('%Y年%m月%d日') %></p>
+  <p>楽曲登録数: <%= @song_pairs.count %></p>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
   # root "articles#index"
   root "home#top"
   resources :users, only: %i[new create]
+  get 'mypage', to: 'users#show', as: :mypage
   get 'signup', to: 'users#new'
   post 'signup', to: 'users#create'
   get 'login', to: 'user_sessions#new'


### PR DESCRIPTION
# 概要
ログイン済みユーザー向けのマイページを作成

# 詳細
ログイン済みのユーザー(`User`)がアクセスできるマイページを作成し、現時点で以下の情報を表示
- ユーザー名(`name`)
- 登録日(`created_at`)
- 楽曲登録数(ユーザーと関連する`SongPair`のデータ数)

マイページには`/mypage`でアクセス出来るようにルーティング設定