### PR TITLE
マイページの登録した曲一覧ページの作成

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,4 +40,5 @@
 /.env.production
 /config/credentials
 /config/credentials.yml.enc
-/maint_bin
+/maintenance/*
+!/maintenance/.keep

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,7 +14,6 @@ AllCops:
     - "Gemfile.lock"
     - "test/**/*"
     - "db/migrate/**/*"
-    # - "app/javascript/**/*"
 
 Style/SpecialGlobalVars:
   EnforcedStyle: use_english_names

--- a/app/controllers/song_pairs_controller.rb
+++ b/app/controllers/song_pairs_controller.rb
@@ -112,32 +112,4 @@ class SongPairsController < ApplicationController
     params.delete(:order)
     params[:q].delete(:similarity_category_id_eq)
   end
-
-  # 検索ページの並べ替え機能用の処理
-  def sort_song_pairs(song_pairs)
-    # 並べ替え用のパラメーターを元に処理を決定
-    case params[:sort_by]
-    when "song_title" # 曲名順
-      song_pairs.joins(:original_song).group('song_pairs.id').reorder('songs.title' => params[:order])
-    when "artist_name" # アーティスト名順
-      # 並び順(params[:order])に合わせて並べ替え
-      if params[:order] == "asc"
-        Kaminari.paginate_array(song_pairs.sort_by { |song_pair| song_pair.original_song.artist_list.downcase })
-      else
-        Kaminari.paginate_array(song_pairs.sort_by { |song_pair| song_pair.original_song.artist_list.downcase }.reverse)
-      end
-    when "created_at" # 登録日順
-      song_pairs.reorder(created_at: params[:order])
-    else
-      song_pairs.order(created_at: :desc)
-    end
-  end
-
-  # 似てるカテゴリーをi18nで翻訳後に格納して出力する処理
-  def similarity_category
-    SimilarityCategory.all.map do |category|
-      category.name = t("similarity_category.#{category.name}")
-      category
-    end
-  end
 end

--- a/app/views/song_pairs/index.html.erb
+++ b/app/views/song_pairs/index.html.erb
@@ -13,7 +13,10 @@
     <% end %>
   </div>
   <div class="mb-4">
-    <% if @song_pairs.blank? %>
+    <% if @song_pairs.present? %>
+      <%= render "shared/song_pair_block", song_pairs: @song_pairs %>
+      <%= paginate @song_pairs %>
+    <% else %>
       <div class="text-center mb-3">
         <p>楽曲が見つかりませんでした。</p>
       </div>
@@ -26,9 +29,6 @@
           <%= link_to "アカウント登録・ログインをして楽曲を登録", login_path, class: "btn" %>
         </div>
       <% end %>
-    <% else %>
-      <%= render "shared/song_pair_block", song_pairs: @song_pairs %>
-      <%= paginate @song_pairs %>
     <% end %>
   </div>
 </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,7 +1,24 @@
 <% set_meta_tags(title: "マイページ", og: { title: "マイページ" }) %>
 <h1 class="text-center mb-4">マイページ</h1>
-<div class="mb-4 user-info">
+<div class="mb-5 user-info">
   <p>ユーザー名: <%= @user.name %></p>
   <p>登録日: <%= @user.created_at.strftime('%Y年%m月%d日') %></p>
   <p>楽曲登録数: <%= @song_pairs.count %></p>
+</div>
+<div>
+  <h2 class="text-center mb-4">登録した曲</h2>
+  <div class="mb-4">
+    <% if @song_pairs.present? %>
+      <%= render "shared/song_pair_block", song_pairs: @song_pairs, maximum: 5 %>
+      <% if @song_pairs.count > 5 %>
+        <div class="more-button d-flex justify-content-center">
+          <%= link_to "全て表示", submit_songs_path, class: "btn" %>
+        </div>
+      <% end %>
+    <% else %>
+      <div class="text-center">
+        <p>楽曲が登録されていません。</p>
+      </div>
+    <% end %>
+  </div>
 </div>

--- a/app/views/users/submit_songs.html.erb
+++ b/app/views/users/submit_songs.html.erb
@@ -1,0 +1,17 @@
+<% set_meta_tags(title: "登録した曲") %>
+<div>
+  <h1 class="text-center mb-4">登録した曲</h1>
+  <div class="d-flex justify-content-center mb-4">
+    <%= render "shared/sort_with_filter", categories: @categories %>
+  </div>
+  <div class="mb-4">
+    <% if @song_pairs.present? %>
+      <%= render "shared/song_pair_block", song_pairs: @song_pairs %>
+      <%= paginate @song_pairs %>
+    <% else %>
+      <div class="text-center mb-3">
+        <p>楽曲が見つかりませんでした。</p>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,8 @@
 Rails.application.routes.draw do
+  # ルート
   root "home#top"
+
+  # ユーザー関連
   resources :users, only: %i[new create]
   get 'mypage', to: 'users#show', as: :mypage
   get 'mypage/submit_songs', to: 'users#submit_songs', as: :submit_songs
@@ -9,6 +12,7 @@ Rails.application.routes.draw do
   post 'login', to: 'user_sessions#create'
   delete 'logout', to: 'user_sessions#destroy'
 
+  # 楽曲関連
   resources :songs, only: %i[show] do
     member do
       get 'melody', to: 'songs#melody_song_pairs'
@@ -19,10 +23,14 @@ Rails.application.routes.draw do
       get 'autocomplete'
     end
   end
+
+  # 楽曲組み合わせ関連
   resources :song_pairs, only: %i[index new create show]
   get 'recent', to: 'song_pairs#recent_page'
   get 'popular', to: 'song_pairs#popularity_page'
   resources :song_pair_evaluations, only: %i[create destroy]
+
+  # アーティスト関連
   resources :artists, only: %i[] do
     collection do
       get 'autocomplete'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,11 +1,8 @@
 Rails.application.routes.draw do
-  # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
-
-  # Defines the root path route ("/")
-  # root "articles#index"
   root "home#top"
   resources :users, only: %i[new create]
   get 'mypage', to: 'users#show', as: :mypage
+  get 'mypage/submit_songs', to: 'users#submit_songs', as: :submit_songs
   get 'signup', to: 'users#new'
   post 'signup', to: 'users#create'
   get 'login', to: 'user_sessions#new'


### PR DESCRIPTION
# 概要
マイページよりアクセスできる登録した曲一覧ページを作成

# 詳細
- マイページに登録した曲の一覧を最大5曲まで表示
- 登録した曲が5曲よりも多くある場合は`全て表示`ボタンを表示
- `全て表示`ボタンから登録した曲一覧ページへ移動することが可能
- 登録した曲一覧ページでは並べ替えやカテゴリーでの絞り込みが可能
- ページネーション対応済み