### PR TITLE
マイページの評価した曲一覧ページの作成

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,17 +4,25 @@ class UsersController < ApplicationController
 
   def show
     @user = current_user
-    @song_pairs = SongPair.includes(:similarity_category, original_song: :artists, similar_song: :artists).where(user_id: @user.id).order(created_at: :desc)
+    @song_pairs = @user.song_pairs.includes(:similarity_category, original_song: :artists, similar_song: :artists).order(created_at: :desc)
+    @evaluated_song_pairs = @user.evaluated_song_pairs.merge(SongPairEvaluation.order(created_at: :desc)).includes(:similarity_category, original_song: :artists, similar_song: :artists)
   end
 
   def submit_songs
     @user = current_user
-    @q = SongPair.where(user_id: @user.id).ransack(params[:q])
-    @song_pairs = @q.result(distinct: true).includes(:similarity_category, original_song: :artists, similar_song: :artists)
+    @q = @user.song_pairs.ransack(params[:q])
+    @song_pairs = @q.result(distinct: true).includes(:similarity_category, original_song: :artists, similar_song: :artists).page(params[:page])
     @categories = similarity_category
 
     # データの並べ替え
     @song_pairs = sort_song_pairs(@song_pairs).page(params[:page])
+  end
+
+  def evaluated_songs
+    @user = current_user
+    @q = @user.evaluated_song_pairs_ordered.ransack(params[:q])
+    @evaluated_song_pairs = @q.result(distinct: true).includes(:similarity_category, original_song: :artists, similar_song: :artists).page(params[:page])
+    @categories = similarity_category
   end
 
   def new

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,4 +24,9 @@ class User < ApplicationRecord
   def song_pair_evaluated?(song_pair)
     evaluated_song_pairs.include?(song_pair)
   end
+
+  # 評価済みのSongPairを評価日時の降順で出力する処理
+  def evaluated_song_pairs_ordered
+    evaluated_song_pairs.select('song_pairs.*, MAX(song_pair_evaluations.created_at) AS evaluation_date').joins(:song_pair_evaluations).group('song_pairs.id').order('evaluation_date DESC')
+  end
 end

--- a/app/views/users/evaluated_songs.html.erb
+++ b/app/views/users/evaluated_songs.html.erb
@@ -1,0 +1,17 @@
+<% set_meta_tags(title: "評価した曲") %>
+<div>
+  <h1 class="text-center mb-4">評価した曲</h1>
+  <div class="d-flex justify-content-center mb-4">
+    <%= render "shared/filter", categories: @categories %>
+  </div>
+  <div class="mb-4">
+    <% if @evaluated_song_pairs.present? %>
+      <%= render "shared/song_pair_block", song_pairs: @evaluated_song_pairs %>
+      <%= paginate @evaluated_song_pairs %>
+    <% else %>
+      <div class="text-center mb-3">
+        <p>楽曲が見つかりませんでした。</p>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -22,3 +22,20 @@
     <% end %>
   </div>
 </div>
+<div>
+  <h2 class="text-center mb-4">評価した曲</h2>
+  <div class="mb-4">
+    <% if @evaluated_song_pairs.present? %>
+      <%= render "shared/song_pair_block", song_pairs: @evaluated_song_pairs, maximum: 5 %>
+      <% if @evaluated_song_pairs.count > 5 %>
+        <div class="more-button d-flex justify-content-center">
+          <%= link_to "全て表示", evaluated_songs_path, class: "btn" %>
+        </div>
+      <% end %>
+    <% else %>
+      <div class="text-center">
+        <p>楽曲が登録されていません。</p>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
   resources :users, only: %i[new create]
   get 'mypage', to: 'users#show', as: :mypage
   get 'mypage/submit_songs', to: 'users#submit_songs', as: :submit_songs
+  get 'mypage/evaluated_songs', to: 'users#evaluated_songs', as: :evaluated_songs
   get 'signup', to: 'users#new'
   post 'signup', to: 'users#create'
   get 'login', to: 'user_sessions#new'


### PR DESCRIPTION
# 概要
マイページよりアクセスできる評価した曲一覧ページを作成

# 詳細
- マイページにユーザーが評価済みの曲を5曲まで表示
- 評価済みの曲が5曲より多い場合は`全て表示`ボタンを表示
- `全て表示`ボタンから評価した曲一覧ページへ移動可能