### PR TITLE
登録した楽曲の編集機能の実装

### DIFF
--- a/app/controllers/song_pairs_controller.rb
+++ b/app/controllers/song_pairs_controller.rb
@@ -77,7 +77,7 @@ class SongPairsController < ApplicationController
       @song_pair.similar_song = similar_song
       @song_pair.user = current_user
 
-      redirect_to @song_pair, notice: '曲のペアが登録されました' if @song_pair.save!
+      redirect_to @song_pair, notice: '楽曲が登録されました' if @song_pair.save!
     rescue ActiveRecord::RecordInvalid => e
       # エラーメッセージを設定
       @song_pair.errors.merge!(e.record.errors)
@@ -91,6 +91,24 @@ class SongPairsController < ApplicationController
     end
   end
 
+  def edit
+    @song_pair = SongPair.find(params[:id])
+    @categories = similarity_category
+    redirect_to @song_pair, alert: "編集権限がありません" unless @song_pair.user == current_user
+  end
+
+  def update
+    @song_pair = SongPair.find(params[:id])
+    redirect_to @song_pair, alert: "編集権限がありません" unless @song_pair.user == current_user
+    if @song_pair.update(song_pair_update_params)
+      redirect_to @song_pair, notice: "楽曲情報を更新しました"
+    else
+      @categories = similarity_category
+      flash.now[:alert] = "入力に誤りがあります"
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
   private
 
   def song_pair_params
@@ -99,6 +117,10 @@ class SongPairsController < ApplicationController
       original_song_attributes: [:title, :release_date, :media_url, { artists_attributes: [:name] }],
       similar_song_attributes: [:title, :release_date, :media_url, { artists_attributes: [:name] }]
     )
+  end
+
+  def song_pair_update_params
+    params.require(:song_pair).permit(:original_song_description, :similar_song_description, :similarity_category_id)
   end
 
   # 未ログインユーザーが検索ページの並べ替え機能などを使用出来ないように制限する処理

--- a/app/controllers/song_pairs_controller.rb
+++ b/app/controllers/song_pairs_controller.rb
@@ -58,6 +58,12 @@ class SongPairsController < ApplicationController
     @current_step = 0
   end
 
+  def edit
+    @song_pair = SongPair.find(params[:id])
+    @categories = similarity_category
+    redirect_to @song_pair, alert: "編集権限がありません" unless @song_pair.user == current_user
+  end
+
   def create
     @song_pair = SongPair.new(song_pair_params)
 
@@ -91,12 +97,6 @@ class SongPairsController < ApplicationController
     end
   end
 
-  def edit
-    @song_pair = SongPair.find(params[:id])
-    @categories = similarity_category
-    redirect_to @song_pair, alert: "編集権限がありません" unless @song_pair.user == current_user
-  end
-
   def update
     @song_pair = SongPair.find(params[:id])
     redirect_to @song_pair, alert: "編集権限がありません" unless @song_pair.user == current_user
@@ -107,6 +107,14 @@ class SongPairsController < ApplicationController
       flash.now[:alert] = "入力に誤りがあります"
       render :edit, status: :unprocessable_entity
     end
+  end
+
+  def destroy
+    @song_pair = SongPair.find(params[:id])
+    redirect_to @song_pair, alert: "編集権限がありません" unless @song_pair.user == current_user
+
+    @song_pair.destroy
+    redirect_to root_path, notice: "曲情報を削除しました"
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -29,4 +29,9 @@ class User < ApplicationRecord
   def evaluated_song_pairs_ordered
     evaluated_song_pairs.select('song_pairs.*, MAX(song_pair_evaluations.created_at) AS evaluation_date').joins(:song_pair_evaluations).group('song_pairs.id').order('evaluation_date DESC')
   end
+
+  # SongPairの登録者かどうかを判断する処理
+  def song_pair_own?(song_pair)
+    song_pairs.include?(song_pair)
+  end
 end

--- a/app/views/song_pairs/edit.html.erb
+++ b/app/views/song_pairs/edit.html.erb
@@ -1,0 +1,46 @@
+<h1 class="text-center mb-4">曲情報を編集</h1>
+<%= form_with model: @song_pair, url: song_pair_path(@song_pair), local: true do |f| %>
+  <% if @song_pair.errors.any? %>
+    <div id="error_explanation" class="alert alert-danger">
+      <ul>
+        <% @song_pair.errors.each do |error| %>
+          <li><%= error.full_message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+  <h3 class="text-center mb-4">カテゴリー</h3>
+  <div class="mb-3">
+    <%= f.collection_select :similarity_category_id, @categories, :id, :name, {}, { class: 'form-select' } %>
+  </div>
+
+  <h3 class="text-center mb-4">曲情報1</h3>
+  <div>
+    <h3>曲名: <%= @song_pair.original_song.title %></h3>
+    <p>アーティスト名: <%= @song_pair.original_song.artist_list %></p>
+    <p>リリース年: <%= @song_pair.original_song.release_date %></p>
+    <%= render 'shared/media_widget', song: @song_pair.original_song %>
+    <div class="mb-3">
+      <%= f.label :original_song_description, "曲1の説明", class: "form-label" %>
+      <%= f.text_area :original_song_description, class: "form-control" %>
+      <p>注目して欲しいポイントや似てると思ったポイントを記載してください。<br>例) 01:20辺りのメロディ</p>
+    </div>
+  </div>
+
+  <h3 class="text-center mb-4">曲情報2</h3>
+  <p class="text-center">※サンプリングカテゴリーであれば曲情報1で入力した曲をサンプリングしている曲になります。</p>
+  <div>
+    <h3>曲名: <%= @song_pair.similar_song.title %></h3>
+    <p>アーティスト名: <%= @song_pair.similar_song.artist_list %></p>
+    <p>リリース年: <%= @song_pair.similar_song.release_date %></p>
+    <%= render 'shared/media_widget', song: @song_pair.similar_song %>
+    <div class="mb-3">
+      <%= f.label :similar_song_description, "曲1の説明", class: "form-label" %>
+      <%= f.text_area :similar_song_description, class: "form-control" %>
+      <p>注目して欲しいポイントや似てると思ったポイントを記載してください。<br>例) 01:20辺りのメロディ</p>
+    </div>
+  </div>
+  <div class="d-flex justify-content-center">
+    <%= f.submit "編集を完了", class: "btn btn-primary btn-block mx-3" %>
+  </div>
+<% end %>

--- a/app/views/song_pairs/edit.html.erb
+++ b/app/views/song_pairs/edit.html.erb
@@ -40,7 +40,10 @@
       <p>注目して欲しいポイントや似てると思ったポイントを記載してください。<br>例) 01:20辺りのメロディ</p>
     </div>
   </div>
-  <div class="d-flex justify-content-center">
+  <div class="d-flex justify-content-center mb-4">
     <%= f.submit "編集を完了", class: "btn btn-primary btn-block mx-3" %>
   </div>
 <% end %>
+<div class="text-center">
+  <%= link_to '曲情報を削除する', song_pair_path(@song_pair), data: { turbo_method: :delete, turbo_confirm: "曲情報を削除しますか？(組み合わせ情報のみ削除されます)" } %>
+</div>

--- a/app/views/song_pairs/show.html.erb
+++ b/app/views/song_pairs/show.html.erb
@@ -5,6 +5,11 @@
 <% else %>
   <h1 class="text-center mb-4">似てる曲情報</h1>
 <% end %>
+<% if current_user.song_pair_own?(@song_pair) %>
+  <div class="text-center mb-4">
+    <%= link_to '曲情報を編集する', edit_song_pair_path %>
+  </div>
+<% end %>
 <div>
   <%= render 'song_info', song: @song_pair.original_song, song_description: @song_pair.original_song_description %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,7 +26,7 @@ Rails.application.routes.draw do
   end
 
   # 楽曲組み合わせ関連
-  resources :song_pairs, only: %i[index new create show]
+  resources :song_pairs, only: %i[index new create show edit update]
   get 'recent', to: 'song_pairs#recent_page'
   get 'popular', to: 'song_pairs#popularity_page'
   resources :song_pair_evaluations, only: %i[create destroy]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,7 +26,7 @@ Rails.application.routes.draw do
   end
 
   # 楽曲組み合わせ関連
-  resources :song_pairs, only: %i[index new create show edit update]
+  resources :song_pairs, only: %i[index new create show edit update destroy]
   get 'recent', to: 'song_pairs#recent_page'
   get 'popular', to: 'song_pairs#popularity_page'
   resources :song_pair_evaluations, only: %i[create destroy]


### PR DESCRIPTION
# 概要
ユーザーが登録した楽曲を編集できる機能を実装

# 詳細
ユーザーが登録した楽曲(`SongPair`)を編集・削除できる機能を以下のように実装
- 似てる曲組み合わせページ上に編集ページへのリンクを設置
- 編集ページ内に削除用のリンクを設置
- 楽曲の説明、カテゴリーを変更可能
- 削除前には確認用のポップアップメッセージを表示