### PR TITLE
メディアの再生時間移動機能の実装

### DIFF
--- a/app/helpers/song_pairs_helper.rb
+++ b/app/helpers/song_pairs_helper.rb
@@ -1,15 +1,27 @@
 module SongPairsHelper
+  # 時間指定部分(12:34のような形式)を自動でウィジェットの再生時間移動リンクに変換するヘルパー
+  # `views/song_pairs/_song_info.html.erb`内で使用
   def parse_time_links(description, media_widget_id)
-    description.gsub(/(\d{1,2}:\d{2})/) do |time|
-      seconds = time_to_seconds(time)
-      link_to time, "javascript:void(0);", class: "time-link", data: { action: "media#seek", media_widget_id: media_widget_id, time: seconds }
-    end.html_safe
+    # 時間指定部分を正規表現で検知し、そこを基準に説明テキストの分割
+    # 変換が必要な部分は変換し`description_parts`に格納
+    description_parts = description.split(/(\d{1,2}:\d{2})/).map do |segment|
+      # 分割されたテキストのうち、時間指定部分であれば再生時間移動リンクに変換、そうでなければそのまま返す
+      if segment.match?(/\A\d{1,2}:\d{2}\z/)
+        seconds = time_to_seconds(segment) # 時間指定部分を秒数に変換
+        link_to(segment, "javascript:void(0);", class: "time-link", data: { action: "media#seek", media_widget_id: media_widget_id, time: seconds })
+      else
+        segment
+      end
+    end
+    # 処理の済んだ文字列を統合して出力
+    safe_join(description_parts)
   end
 
   private
 
+  # 時間指定部分(12:34のような形式)から秒数値を取得する処理
   def time_to_seconds(time_str)
-    minutes, seconds = time_str.split(":").map(&:to_i)
-    minutes * 60 + seconds
+    minutes, seconds = time_str.split(":").map(&:to_i) # `12:34`の形式を秒数計算出来るように分割
+    (minutes * 60) + seconds # 出力する秒数(計算結果)
   end
 end

--- a/app/helpers/song_pairs_helper.rb
+++ b/app/helpers/song_pairs_helper.rb
@@ -1,0 +1,15 @@
+module SongPairsHelper
+  def parse_time_links(description, media_widget_id)
+    description.gsub(/(\d{1,2}:\d{2})/) do |time|
+      seconds = time_to_seconds(time)
+      link_to time, "javascript:void(0);", class: "time-link", data: { action: "media#seek", media_widget_id: media_widget_id, time: seconds }
+    end.html_safe
+  end
+
+  private
+
+  def time_to_seconds(time_str)
+    minutes, seconds = time_str.split(":").map(&:to_i)
+    minutes * 60 + seconds
+  end
+end

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -2,10 +2,13 @@
 // Run that command whenever you add a new controller or create them with
 // ./bin/rails generate stimulus controllerName
 
-import { application } from "./application"
+import { application } from "./application";
 
-import AutoCompleteController from "./autocomplete_controller"
-application.register("autocomplete", AutoCompleteController)
+import AutoCompleteController from "./autocomplete_controller";
+application.register("autocomplete", AutoCompleteController);
 
-import MultiStepFormController from "./multi_step_form_controller"
-application.register("multi-step-form", MultiStepFormController)
+import MultiStepFormController from "./multi_step_form_controller";
+application.register("multi-step-form", MultiStepFormController);
+
+import MediaController from "./media_controller";
+application.register("media", MediaController);

--- a/app/javascript/controllers/media_controller.js
+++ b/app/javascript/controllers/media_controller.js
@@ -1,0 +1,19 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+  static targets = ["widget"];
+
+  seek(event) {
+    event.preventDefault();
+    const mediaWidgetId = event.currentTarget.dataset.mediaWidgetId;
+    const widgetDiv = document.getElementById(mediaWidgetId);
+    const iframe = widgetDiv ? widgetDiv.querySelector("iframe") : null;
+    
+    if (iframe) {
+      const time = parseInt(event.currentTarget.dataset.time, 10);
+      let videoSrc = iframe.src.split("?")[0];
+      videoSrc += `?start=${time}&autoplay=1&enablejsapi=1`;
+      iframe.src = videoSrc;
+    }
+  }
+}

--- a/app/javascript/controllers/media_controller.js
+++ b/app/javascript/controllers/media_controller.js
@@ -1,16 +1,21 @@
+// SongPairsHelperのparse_time_linksメソッドで変換された再生時間移動リンクのクリックを検知し、対応するプレイヤーウィジェットを再生する処理
 import { Controller } from "@hotwired/stimulus";
 
 export default class extends Controller {
+  // ウィジェットをターゲットに
   static targets = ["widget"];
 
+  // クリック時に行う処理
   seek(event) {
-    event.preventDefault();
-    const mediaWidgetId = event.currentTarget.dataset.mediaWidgetId;
-    const widgetDiv = document.getElementById(mediaWidgetId);
-    const iframe = widgetDiv ? widgetDiv.querySelector("iframe") : null;
+    const mediaWidgetId = event.currentTarget.dataset.mediaWidgetId; // ウィジェットのidを取得
+    const widgetDiv = document.getElementById(mediaWidgetId); // ウィジェット(iframe)を含む親要素divの取得
+    const iframe = widgetDiv ? widgetDiv.querySelector("iframe") : null; // ウィジェットの本体(iframe)部分の取得
     
+    // iframeが存在していれば指定の再生時間に移動するようにウィジェット設定を変更
     if (iframe) {
-      const time = parseInt(event.currentTarget.dataset.time, 10);
+      const time = parseInt(event.currentTarget.dataset.time, 10); // 指定された再生時間の秒数を10進数で取得
+
+      // ウィジェットの設定(Src部分のURLを置き換えることで変更)
       let videoSrc = iframe.src.split("?")[0];
       videoSrc += `?start=${time}&autoplay=1&enablejsapi=1`;
       iframe.src = videoSrc;

--- a/app/views/shared/_media_widget.html.erb
+++ b/app/views/shared/_media_widget.html.erb
@@ -1,4 +1,4 @@
-<div class="media-widget">
+<div class="media-widget" id="<%= defined?(element_id) && element_id + "-media-widget" || "media-widget" %>" data-controller="media" data-media-target="widget">
   <% if song.media_url_id.present? %>
       <iframe src="https://www.youtube.com/embed/<%= song.media_url_id %>" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
   <% else %>

--- a/app/views/song_pairs/_song_info.html.erb
+++ b/app/views/song_pairs/_song_info.html.erb
@@ -1,4 +1,4 @@
-<div class="mb-4 song-info-block">
+<div class="mb-4 song-info-block" id="<%= element_id %>-info">
   <div class="d-flex">
     <div class="song-info">
       <h3><%= link_to song.title, song %></h3>
@@ -9,9 +9,9 @@
       <%= image_tag "https://img.youtube.com/vi/#{song.media_url_id}/hqdefault.jpg", class: "song-jacket" %>
     </div>
   </div>
-  <%= render 'shared/media_widget', song: song %>
-  <div class="song-description">
+  <%= render 'shared/media_widget', song: song, element_id: element_id %>
+  <div class="song-description" id="<%= element_id %>-description" data-controller="media">
     <h5>説明:</h5>
-    <p><%= song_description %></p>
+    <p><%= parse_time_links(song_description, "#{element_id}-media-widget") %></p>
   </div>
 </div>

--- a/app/views/song_pairs/new.html.erb
+++ b/app/views/song_pairs/new.html.erb
@@ -88,7 +88,7 @@
       <div class="mb-3">
         <%= f.label :original_song_description, "曲1の説明", class: "form-label" %>
         <%= f.text_area :original_song_description, class: "form-control" %>
-        <p>注目して欲しいポイントや似てると思ったポイントを記載してください。<br>例) 01:20辺りのメロディ</p>
+        <p>注目して欲しいポイントや似てると思ったポイントを記載してください。<br>半角で12:34のように記述するとページ上で自動的に再生時間指定リンクに変換されます。<br>例) 01:20辺りのメロディ</p>
       </div>
     </div>
 

--- a/app/views/song_pairs/show.html.erb
+++ b/app/views/song_pairs/show.html.erb
@@ -5,7 +5,7 @@
 <% else %>
   <h1 class="text-center mb-4">似てる曲情報</h1>
 <% end %>
-<% if current_user.song_pair_own?(@song_pair) %>
+<% if logged_in? && current_user.song_pair_own?(@song_pair) %>
   <div class="text-center mb-4">
     <%= link_to '曲情報を編集する', edit_song_pair_path %>
   </div>

--- a/app/views/song_pairs/show.html.erb
+++ b/app/views/song_pairs/show.html.erb
@@ -11,7 +11,7 @@
   </div>
 <% end %>
 <div>
-  <%= render 'song_info', song: @song_pair.original_song, song_description: @song_pair.original_song_description %>
+  <%= render 'song_info', song: @song_pair.original_song, song_description: @song_pair.original_song_description, element_id: 'original-song' %>
 
   <% if @song_pair.similarity_category.id == 3 %>
     <h2 class="text-center mb-4">↓サンプリングされてる</h2>
@@ -19,7 +19,7 @@
     <h2 class="text-center mb-4">↓似てる: <%= @song_pair.similarity_category_name %></h2>
   <% end %>
   
-  <%= render 'song_info', song: @song_pair.similar_song, song_description: @song_pair.similar_song_description %>
+  <%= render 'song_info', song: @song_pair.similar_song, song_description: @song_pair.similar_song_description, element_id: 'similar-song' %>
   
   <div class="user-info-block text-center mb-4">
     <h3>登録したユーザー</h3>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   db:
     image: mysql:8.0


### PR DESCRIPTION
# 概要
メディアプレイヤーウィジェットの再生時間移動機能を実装

# 詳細
似てる曲ページにて表示されているプレイヤーウィジェットを対応する楽曲説明の再生時間指定部分(`mm:ss`)を自動で再生時間移動リンクに変換し、指定された再生時間から再生できる機能を実装
- Stimulusの専用のコントローラーを作成(`media_controller.js`)
- `mm:ss`形式の表記からaタグのリンクに変換する処理は`song_pairs_helper.rb`で実装
- リンクをクリックするとStimulusコントローラーによって指定時間を再生するように設定
- `mm:ss`形式で時間指定ができる旨を楽曲登録フォームの説明に追加

# その他修正
- 未ログインユーザーが表示できないページがあったバグを修正