### PR TITLE
楽曲登録フォームのオートコンプリート機能の調整

### DIFF
--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -343,6 +343,11 @@ footer {
     width: 100%;
 }
 
+.song-submit-form {
+    position: relative;
+    width: 100%;
+}
+
 .list-group {
     position: absolute;
     width: 100%;

--- a/app/controllers/autocomplete_controller.rb
+++ b/app/controllers/autocomplete_controller.rb
@@ -14,16 +14,20 @@ class AutocompleteController < ApplicationController
 
   # 楽曲登録フォームの楽曲用の処理
   def songs
-    query = "%#{params[:query]}%"
+    query = "%#{params[:q]}%"
     songs = Song.where("title LIKE ?", query).limit(10)
-    render json: songs.map { |song|
+    results = songs.map do |song|
       {
-        title: song.title,
-        artists: song.artists.map(&:name).join(','),
+        id: song.id,
+        text: "#{song.title} - #{song.artists.map(&:name).join(", ")}",
+        label: song.title,
+        artist: song.artists.map(&:name).join(", "),
         release_date: song.release_date,
         media_url: song.media_url
       }
-    }
+    end
+
+    render partial: "autocomplete/song_submit", locals: { results: results }
   end
 
   # 楽曲登録フォームのアーティスト用の処理

--- a/app/controllers/autocomplete_controller.rb
+++ b/app/controllers/autocomplete_controller.rb
@@ -28,8 +28,10 @@ class AutocompleteController < ApplicationController
 
   # 楽曲登録フォームのアーティスト用の処理
   def artists
-    query = "%#{params[:query]}%"
+    query = "%#{params[:q]}%"
     artists = Artist.where("name LIKE ?", query).limit(10)
-    render json: artists.pluck(:name)
+
+    results = artists.map { |artist| { id: artist.id, text: artist.name } }
+    render partial: "artist", locals: { results: results }
   end
 end

--- a/app/controllers/autocomplete_controller.rb
+++ b/app/controllers/autocomplete_controller.rb
@@ -19,7 +19,7 @@ class AutocompleteController < ApplicationController
     results = songs.map do |song|
       {
         id: song.id,
-        text: "#{song.title} - #{song.artists.map(&:name).join(", ")}",
+        text: "#{song.title} - #{song.artists.map(&:name).join(', ')}",
         label: song.title,
         artist: song.artists.map(&:name).join(", "),
         release_date: song.release_date,

--- a/app/javascript/controllers/autocomplete_controller.js
+++ b/app/javascript/controllers/autocomplete_controller.js
@@ -1,107 +1,36 @@
-// オートコンプリート機能用のコード
-import { Controller } from "@hotwired/stimulus"
+// 楽曲登録フォームの曲名部分のオートコンプリート機能処理部分
+// stilumus-autocompleteを拡張し、自動入力対象を曲名だけでなく関連するアーティストやリリース年などのフォームに広げる
+import { Autocomplete } from "stimulus-autocomplete";
 
-export default class extends Controller {
-  // オートコンプリートのターゲットを指定
-  static targets = ["songInput", "artistInput", "releaseDate", "mediaUrl", "songList1", "songList2", "artistList1", "artistList2"]
+export default class extends Autocomplete {
+  // オートコンプリート機能の対象になるフォームを設定
+  // input: 曲名
+  // artist: アーティスト名
+  // releaseDate: リリース年
+  // mediaUrl: メディアURL
+  static targets = ["input", "artist", "releaseDate", "mediaUrl"];
 
-  // 楽曲情報の検索
-  search() {
-    // 入力を取得
-    const query = this.songInputTarget.value
+  commit(selected) {
+    const label = selected.getAttribute("data-autocomplete-label"); // 曲名
+    const artist = selected.getAttribute("data-artist"); // アーティスト名
+    const releaseDate = selected.getAttribute("data-release-date"); // リリース年
+    const mediaUrl = selected.getAttribute("data-media-url"); // メディアURL
 
-    // 入力が2文字未満の場合はサジェストを表示しない
-    if (query.length < 2) {
-      this.clearSuggestions(this.currentSongListTarget())
-      return
+    // 入力フィールドに曲名を反映
+    this.inputTarget.value = label;
+
+    // 対応するフィールドにそれぞれの値を反映
+    if (this.hasArtistTarget) {
+      this.artistTarget.value = artist || "";
+    }
+    if (this.hasReleaseDateTarget) {
+      this.releaseDateTarget.value = releaseDate || "";
+    }
+    if (this.hasMediaUrlTarget) {
+      this.mediaUrlTarget.value = mediaUrl || "";
     }
 
-    // サジェストの取得と表示の処理
-    fetch(`/songs/autocomplete?query=${query}`)
-      .then(response => response.json())
-      .then(data => {
-        this.showSuggestions(this.currentSongListTarget(), data, (suggestion) => {
-          this.setSongData(suggestion)
-        })
-      })
-  }
-
-  // アーティスト情報の検索
-  searchArtist() {
-    // 入力を取得
-    const query = this.artistInputTarget.value
-
-    // 入力が2文字未満の場合はサジェストを表示しない
-    if (query.length < 2) {
-      this.clearSuggestions(this.currentArtistListTarget())
-      return
-    }
-
-    // サジェストの取得と表示の処理
-    fetch(`/artists/autocomplete?query=${query}`)
-      .then(response => response.json())
-      .then(data => {
-        this.showSuggestions(this.currentArtistListTarget(), data, (suggestion) => {
-          this.artistInputTarget.value = suggestion
-        })
-      })
-  }
-
-  // 現在の入力フィールドに対応する曲候補リストを取得
-  currentSongListTarget() {
-    if (this.hasSongList1Target && this.songInputTarget.dataset.target === "autocomplete.songInput") {
-      return this.songList1Target
-    } else if (this.hasSongList2Target && this.songInputTarget.dataset.target === "autocomplete.songInput") {
-      return this.songList2Target
-    } else {
-      return null;
-    }
-  }
-
-  // 現在の入力フィールドに対応するアーティスト候補リストを取得
-  currentArtistListTarget() {
-    if (this.hasArtistList1Target && this.artistInputTarget.dataset.target === "autocomplete.artistInput") {
-      return this.artistList1Target
-    } else if (this.hasArtistList2Target && this.artistInputTarget.dataset.target === "autocomplete.artistInput") {
-      return this.artistList2Target
-    }
-  }
-
-  // オートコンプリート部分の処理
-  setSongData(suggestion) {
-    this.songInputTarget.value = suggestion.title;
-    this.artistInputTarget.value = suggestion.artists || '';
-    this.releaseDateTarget.value = suggestion.release_date || '';
-    this.mediaUrlTarget.value = suggestion.media_url || '';
-  }
-
-  // オートコンプリート候補を表示する共通関数
-  showSuggestions(listElement, suggestions, callback) {
-    this.clearSuggestions(listElement) // 既存の候補をクリア
-
-    suggestions.forEach(suggestion => {
-      const listItem = document.createElement("li")
-      listItem.textContent = typeof suggestion === 'string' ? suggestion : suggestion.title;  // 曲の場合はタイトルを表示
-      listItem.classList.add("autocomplete-item")
-      listItem.addEventListener("click", () => {
-        callback(suggestion)
-        this.clearSuggestions(listElement)
-      })
-      listElement.appendChild(listItem)
-    })
-  }
-
-  // 候補がクリックされたときに入力フィールドに反映する
-  setInputValue(target, value) {
-    target.value = value
-  }
-
-  // 候補リストをクリアする
-  clearSuggestions(listElement) {
-    if(!listElement) return;
-
-    while (listElement.firstChild) {
-      listElement.removeChild(listElement.firstChild)
-    }
+    // リストを閉じる
+    this.close();
   }
 }

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -15,3 +15,6 @@ application.register("multi-step-form", MultiStepFormController)
 
 import SearchAutocompleteController from "stimulus-autocomplete";
 application.register("search-autocomplete", SearchAutocompleteController);
+
+import ArtistAutocompleteController from "stimulus-autocomplete";
+application.register("artist-autocomplete", ArtistAutocompleteController);

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -7,14 +7,15 @@ import { application } from "./application"
 import AutocompleteController from "./autocomplete_controller"
 application.register("autocomplete", AutocompleteController)
 
+import SearchAutocompleteController from "stimulus-autocomplete";
+application.register("search-autocomplete", SearchAutocompleteController);
+
+import ArtistAutocompleteController from "stimulus-autocomplete";
+application.register("artist-autocomplete", ArtistAutocompleteController);
+
 import MediaController from "./media_controller"
 application.register("media", MediaController)
 
 import MultiStepFormController from "./multi_step_form_controller"
 application.register("multi-step-form", MultiStepFormController)
 
-import SearchAutocompleteController from "stimulus-autocomplete";
-application.register("search-autocomplete", SearchAutocompleteController);
-
-import ArtistAutocompleteController from "stimulus-autocomplete";
-application.register("artist-autocomplete", ArtistAutocompleteController);

--- a/app/views/autocomplete/_artist.html.erb
+++ b/app/views/autocomplete/_artist.html.erb
@@ -1,5 +1,5 @@
 <% results.each do |result| %>
-  <li class="list-group-item" role="option" data-id="<%= result[:id] %>" data-value="<%= result[:text] %>">
+  <li class="list-group-item" role="option" data-autocomplete-value="<%= result[:id] %>" data-autocomplete-label="<%= result[:text] %>">
     <%= result[:text] %>
   </li>
 <% end %>

--- a/app/views/autocomplete/_artist.html.erb
+++ b/app/views/autocomplete/_artist.html.erb
@@ -1,0 +1,5 @@
+<% results.each do |result| %>
+  <li class="list-group-item" role="option" data-id="<%= result[:id] %>" data-value="<%= result[:text] %>">
+    <%= result[:text] %>
+  </li>
+<% end %>

--- a/app/views/autocomplete/_search.html.erb
+++ b/app/views/autocomplete/_search.html.erb
@@ -1,5 +1,5 @@
 <% results.each do |result| %>
-  <li class="list-group-item" role="option" data-id="<%= result[:id] %>" data-value="<%= result[:text] %>", data-autocomplete-label="<%= result[:label] %>">
+  <li class="list-group-item" role="option" data-autocomplete-value="<%= result[:id] %>" data-autocomplete-label="<%= result[:label] %>">
     <%= result[:text] %>
   </li>
 <% end %>

--- a/app/views/autocomplete/_song_submit.html.erb
+++ b/app/views/autocomplete/_song_submit.html.erb
@@ -1,5 +1,5 @@
 <% results.each do |result| %>
-  <li class="list-group-item" role="option" data-id="<%= result[:id] %>" data-value="<%= result[:text] %>", data-autocomplete-label="<%= result[:label] %>">
+  <li class="list-group-item" role="option" data-autocomplete-value="<%= result[:id] %>" data-autocomplete-label="<%= result[:label] %>" data-artist="<%= result[:artist] %>" data-release-date="<%= result[:release_date] %>" data-media-url="<%= result[:media_url] %>">
     <%= result[:text] %>
   </li>
 <% end %>

--- a/app/views/autocomplete/_song_submit.html.erb
+++ b/app/views/autocomplete/_song_submit.html.erb
@@ -1,0 +1,5 @@
+<% results.each do |result| %>
+  <li class="list-group-item" role="option" data-id="<%= result[:id] %>" data-value="<%= result[:text] %>", data-autocomplete-label="<%= result[:label] %>">
+    <%= result[:text] %>
+  </li>
+<% end %>

--- a/app/views/song_pairs/new.html.erb
+++ b/app/views/song_pairs/new.html.erb
@@ -65,10 +65,11 @@
           <ul data-autocomplete-target="songList1" class="autocomplete-list"></ul>
         </div>
         <%= song1_form.fields_for :artists do |artist1_form| %>
-          <div class="mb-3">
+          <div class="mb-3 song-submit-form" data-controller="artist-autocomplete" data-artist-autocomplete-url-value=<%= autocomplete_artists_path %>>
             <%= artist1_form.label :name, "アーティスト名", class: "form-label" %>
-            <%= artist1_form.text_field :name, class: "form-control", data: { action: "input->autocomplete#searchArtist", target: "autocomplete.artistInput" } %>
-            <ul data-autocomplete-target="artistList1" class="autocomplete-list"></ul>
+            <%= artist1_form.text_field :name, class: "form-control", data: { artist_autocomplete_target: "input", target: "autocomplete.artistInput" } %>
+            <%= artist1_form.hidden_field :name, data: { artist_autocomplete_target: "hidden" } %>
+            <ul data-artist-autocomplete-target="results" class="list-group"></ul>
           </div>
         <% end %>
         <div class="mb-3">
@@ -102,10 +103,11 @@
           <ul data-autocomplete-target="songList2" class="autocomplete-list"></ul>
         </div>
         <%= song2_form.fields_for :artists do |artist2_form| %>
-          <div class="mb-3">
+          <div class="mb-3 song-submit-form" data-controller="artist-autocomplete" data-artist-autocomplete-url-value=<%= autocomplete_artists_path %>>
             <%= artist2_form.label :name, "アーティスト名", class: "form-label" %>
-            <%= artist2_form.text_field :name, class: "form-control", data: { action: "input->autocomplete#searchArtist", target: "autocomplete.artistInput" } %>
-            <ul data-autocomplete-target="artistList2" class="autocomplete-list"></ul>
+            <%= artist2_form.text_field :name, class: "form-control", data: { artist_autocomplete_target: "input", target: "autocomplete.artistInput" } %>
+            <%= artist2_form.hidden_field :name, data: { artist_autocomplete_target: "hidden" } %>
+            <ul data-artist-autocomplete-target="results" class="list-group"></ul>
           </div>
         <% end %>
         <div class="mb-3">

--- a/app/views/song_pairs/new.html.erb
+++ b/app/views/song_pairs/new.html.erb
@@ -57,28 +57,29 @@
 
     <h3 class="text-center mb-4">曲情報1</h3>
     <p class="text-center">曲の情報を入力してください。</p>
-    <div data-controller="autocomplete">
+    <div data-controller="autocomplete" data-autocomplete-url-value=<%= autocomplete_songs_path %>>
       <%= f.fields_for :original_song do |song1_form| %>
-        <div class="mb-3">
+        <div class="mb-3 song-submit-form">
           <%= song1_form.label :title, "曲名", class: "form-label" %>
-          <%= song1_form.text_field :title, class: "form-control", data: { action: "input->autocomplete#search", target: "autocomplete.songInput" } %>
-          <ul data-autocomplete-target="songList1" class="autocomplete-list"></ul>
+          <%= song1_form.text_field :title, class: "form-control", data: { autocomplete_target: "input" } %>
+          <%= song1_form.hidden_field :title, data: { autocomplete_target: "hidden" } %>
+          <ul class="list-group" data-autocomplete-target="results"></ul>
         </div>
         <%= song1_form.fields_for :artists do |artist1_form| %>
           <div class="mb-3 song-submit-form" data-controller="artist-autocomplete" data-artist-autocomplete-url-value=<%= autocomplete_artists_path %>>
             <%= artist1_form.label :name, "アーティスト名", class: "form-label" %>
-            <%= artist1_form.text_field :name, class: "form-control", data: { artist_autocomplete_target: "input", target: "autocomplete.artistInput" } %>
+            <%= artist1_form.text_field :name, class: "form-control", data: { artist_autocomplete_target: "input", autocomplete_target: "artist" } %>
             <%= artist1_form.hidden_field :name, data: { artist_autocomplete_target: "hidden" } %>
             <ul data-artist-autocomplete-target="results" class="list-group"></ul>
           </div>
         <% end %>
         <div class="mb-3">
           <%= song1_form.label :release_date, "リリース年", class: "form-label" %>
-          <%= song1_form.select :release_date, options_for_select((1870..Date.today.year).to_a.reverse.map(&:to_s), song1_form.object.release_date), {}, class: "form-select", data: { field: 'year', target: "autocomplete.releaseDate" } %>
+          <%= song1_form.select :release_date, options_for_select((1870..Date.today.year).to_a.reverse.map(&:to_s), song1_form.object.release_date), {}, class: "form-select", data: { field: 'year', autocomplete_target: "releaseDate" } %>
         </div>
         <div class="mb-3">
           <%= song1_form.label :media_url, "メディアURL", class: "form-label" %>
-          <%= song1_form.text_field :media_url, class: "form-control", id: "media_url_1", data: { target: "autocomplete.mediaUrl" } %>
+          <%= song1_form.text_field :media_url, class: "form-control", id: "media_url_1", data: { autocomplete_target: "mediaUrl" } %>
           <p>YouTubeのURLに対応しています。</p>
         </div>
         <div class="mb-3">
@@ -95,28 +96,28 @@
 
     <h3 class="text-center mb-4">曲情報2</h3>
     <p class="text-center">似てる曲の情報を入力してください。<br>※サンプリングカテゴリーであれば曲情報1で入力した曲をサンプリングしている曲になります。</p>
-    <div data-controller="autocomplete">
+    <div data-controller="autocomplete" data-autocomplete-url-value=<%= autocomplete_songs_path %>>
       <%= f.fields_for :similar_song do |song2_form| %>
-        <div class="mb-3">
+        <div class="mb-3 song-submit-form">
           <%= song2_form.label :title, "曲名", class: "form-label" %>
-          <%= song2_form.text_field :title, class: "form-control", data: { action: "input->autocomplete#search", target: "autocomplete.songInput" } %>
-          <ul data-autocomplete-target="songList2" class="autocomplete-list"></ul>
+          <%= song2_form.text_field :title, class: "form-control", data: { autocomplete_target: "input" } %>
+          <ul class="list-group" data-autocomplete-target="results"></ul>
         </div>
         <%= song2_form.fields_for :artists do |artist2_form| %>
           <div class="mb-3 song-submit-form" data-controller="artist-autocomplete" data-artist-autocomplete-url-value=<%= autocomplete_artists_path %>>
             <%= artist2_form.label :name, "アーティスト名", class: "form-label" %>
-            <%= artist2_form.text_field :name, class: "form-control", data: { artist_autocomplete_target: "input", target: "autocomplete.artistInput" } %>
+            <%= artist2_form.text_field :name, class: "form-control", data: { artist_autocomplete_target: "input", autocomplete_target: "artist" } %>
             <%= artist2_form.hidden_field :name, data: { artist_autocomplete_target: "hidden" } %>
             <ul data-artist-autocomplete-target="results" class="list-group"></ul>
           </div>
         <% end %>
         <div class="mb-3">
           <%= song2_form.label :release_date, "リリース年", class: "form-label" %>
-          <%= song2_form.select :release_date, options_for_select((1870..Date.today.year).to_a.reverse.map(&:to_s), song2_form.object.release_date), {}, class: "form-select", data: { field: 'year', target: "autocomplete.releaseDate" } %>
+          <%= song2_form.select :release_date, options_for_select((1870..Date.today.year).to_a.reverse.map(&:to_s), song2_form.object.release_date), {}, class: "form-select", data: { field: 'year', autocomplete_target: "releaseDate" } %>
         </div>
         <div class="mb-3">
           <%= song2_form.label :media_url, "メディアURL", class: "form-label" %>
-          <%= song2_form.text_field :media_url, class: "form-control", id: "media_url_2", data: { target: "autocomplete.mediaUrl" } %>
+          <%= song2_form.text_field :media_url, class: "form-control", id: "media_url_2", data: { autocomplete_target: "mediaUrl" } %>
           <p>YouTubeのURLに対応しています。</p>
         </div>
         <div class="mb-3">


### PR DESCRIPTION
# 概要
楽曲登録フォーム内のオートコンプリート機能の仕様を調整

# 詳細
楽曲登録フォーム内の曲名やアーティスト名によるオートコンプリート機能を独自の機能からstimulus-autocompleteを使用したモノに置き換えを行う
機能の置き換えに伴い以下のビューを作成
- `autocomplete/_artist.html.erb`: アーティスト名のオートコンプリート用
- `autocomplete/_song_submit.html.erb`: 曲名のオートコンプリート用

機能実装や拡張の為のコードは引き続き`javascript/controllers/autocomplete_controller.js`を使用
アーティスト名によるオートコンプリート機能は拡張の必要性がないため独立させて新たに`artist-autocomplete`としてStimulusコントローラーを定義して使用