### PR TITLE
管理者ページの`SongPair`管理機能の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -94,3 +94,5 @@ gem "ahoy_matey"
 gem "kaminari"
 
 gem "meta-tags"
+
+gem "gretel"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -117,6 +117,9 @@ GEM
       net-http
     globalid (1.2.1)
       activesupport (>= 6.1)
+    gretel (5.0.1)
+      actionview (>= 6.1)
+      railties (>= 6.1)
     hashie (5.0.0)
     i18n (1.14.6)
       concurrent-ruby (~> 1.0)
@@ -355,6 +358,7 @@ DEPENDENCIES
   cssbundling-rails
   debug
   dotenv-rails
+  gretel
   jbuilder
   jsbundling-rails
   kaminari

--- a/app/assets/stylesheets/admin.sass.scss
+++ b/app/assets/stylesheets/admin.sass.scss
@@ -1,0 +1,4 @@
+iframe {
+    width: 100%;
+    aspect-ratio: 16 / 9;
+}

--- a/app/controllers/admin/song_pairs_controller.rb
+++ b/app/controllers/admin/song_pairs_controller.rb
@@ -1,0 +1,37 @@
+module Admin
+  class SongPairsController < BaseController
+    layout 'admin'
+
+    def index
+      @song_pairs = SongPair.includes(:similarity_category, original_song: :artists, similar_song: :artists)
+    end
+
+    def edit
+      @song_pair = SongPair.find(params[:id])
+      @categories = similarity_category
+    end
+
+    def update
+      @song_pair = SongPair.find(params[:id])
+      if @song_pair.update(song_pair_params)
+        redirect_to admin_song_pairs_path, notice: "楽曲情報を更新しました"
+      else
+        @categories = similarity_category
+        flash.now[:alert] = "入力に誤りがあります"
+        render :edit, status: :unprocessable_entity
+      end
+    end
+
+    def destroy
+      @song_pair = SongPair.find(params[:id])
+      @song_pair.destroy
+      redirect_to admin_song_pairs_path, notice: "削除しました"
+    end
+
+    private
+
+    def song_pair_params
+      params.require(:song_pair).permit(:original_song_description, :similar_song_description, :similarity_category_id)
+    end
+  end
+end

--- a/app/views/admin/dashboards/top.html.erb
+++ b/app/views/admin/dashboards/top.html.erb
@@ -1,12 +1,4 @@
-<div class="app-content-header">
-  <div class="container-fluid">
-    <div class="row">
-      <div class="col-sm-6">
-        <h1>管理者ページ</h1>
-      </div>
-    </div>
-  </div>
-</div>
+<%= render 'admin/shared/content_header', header_title: "管理者ページ" %>
 <div class="app-content">
   <div class="container-fluid">
     <div class="row">

--- a/app/views/admin/shared/_content_header.html.erb
+++ b/app/views/admin/shared/_content_header.html.erb
@@ -1,6 +1,9 @@
 <div class="app-content-header">
   <div class="container-fluid">
     <div class="row">
+      <div class="breadcrumbs">
+        <%= breadcrumbs style: :bootstrap5 %>
+      </div>
       <div class="col-sm-6">
         <h1><%= header_title %></h1>
       </div>

--- a/app/views/admin/shared/_content_header.html.erb
+++ b/app/views/admin/shared/_content_header.html.erb
@@ -1,0 +1,9 @@
+<div class="app-content-header">
+  <div class="container-fluid">
+    <div class="row">
+      <div class="col-sm-6">
+        <h1><%= header_title %></h1>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/song_pairs/edit.html.erb
+++ b/app/views/admin/song_pairs/edit.html.erb
@@ -1,3 +1,4 @@
+<% breadcrumb :edit_admin_song_pair, @song_pair %>
 <%= render 'admin/shared/content_header', header_title: "似てる曲組み合わせの編集" %>
 <div class="app-content">
   <div class="container-fluid">

--- a/app/views/admin/song_pairs/edit.html.erb
+++ b/app/views/admin/song_pairs/edit.html.erb
@@ -1,0 +1,71 @@
+<%= render 'admin/shared/content_header', header_title: "似てる曲組み合わせの編集" %>
+<div class="app-content">
+  <div class="container-fluid">
+    <div class="row">
+      <%= form_with model: @song_pair, url: admin_song_pair_path(@song_pair), local: true do |f| %>
+        <% if @song_pair.errors.any? %>
+          <div id="error_explanation" class="alert alert-danger">
+            <ul>
+              <% @song_pair.errors.each do |error| %>
+                <li><%= error.full_message %></li>
+              <% end %>
+            </ul>
+          </div>
+        <% end %>
+        <h3 class="text-center mb-4">カテゴリー</h3>
+        <div class="mb-3">
+          <%= f.collection_select :similarity_category_id, @categories, :id, :name, {}, { class: 'form-select' } %>
+        </div>
+        <table class="table table-bordered">
+          <thead>
+            <tr>
+              <th></th>
+              <th>曲情報1</th>
+              <th>曲情報2</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>曲名</td>
+              <td><%= @song_pair.original_song.title %></td>
+              <td><%= @song_pair.similar_song.title %></td>
+            </tr>
+            <tr>
+              <td>アーティスト名</td>
+              <td><%= @song_pair.original_song.artist_list %></td>
+              <td><%= @song_pair.similar_song.artist_list %></td>
+            </tr>
+            <tr>
+              <td>リリース年</td>
+              <td><%= @song_pair.original_song.release_date %></td>
+              <td><%= @song_pair.similar_song.release_date %></td>
+            </tr>
+            <tr>
+              <td>メディアURL</td>
+              <td>
+                <%= render 'shared/media_widget', song: @song_pair.original_song %>
+                <%= @song_pair.original_song.media_url %>
+              </td>
+              <td>
+                <%= render 'shared/media_widget', song: @song_pair.similar_song %>
+                <%= @song_pair.similar_song.media_url %>
+              </td>
+            </tr>
+            <tr>
+              <td>説明</td>
+              <td>
+                <%= f.text_area :original_song_description, class: "form-control" %>
+              </td>
+              <td>
+                <%= f.text_area :similar_song_description, class: "form-control" %>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        <div class="d-flex justify-content-center mb-4">
+          <%= f.submit "編集を完了", class: "btn btn-primary btn-block mx-3" %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/song_pairs/index.html.erb
+++ b/app/views/admin/song_pairs/index.html.erb
@@ -1,0 +1,39 @@
+<%= render 'admin/shared/content_header', header_title: "似てる曲組み合わせ" %>
+<div class="app-content">
+  <div class="container-fluid">
+    <div class="row">
+      <table class="table">
+        <thead>
+          <tr>
+            <th>ID</th>
+            <th>original_song</th>
+            <th>similar_song</th>
+            <th>カテゴリー</th>
+            <th>ユーザー</th>
+            <th></th>
+            <th>登録日時</th>
+            <th>更新日時</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% @song_pairs.each do |song_pair| %>
+            <tr>
+              <td><%= song_pair.id %></td>
+              <td><%= song_pair.original_song.artist_list %> / <%= song_pair.original_song.title %></td>
+              <td><%= song_pair.similar_song.artist_list %> / <%= song_pair.similar_song.title %></td>
+              <td><%= song_pair.similarity_category_name %></td>
+              <td><%= song_pair.user.name %></td>
+              <td>
+                <%= link_to "閲覧", song_pair_path(song_pair) %>
+                <%= link_to "編集", edit_admin_song_pair_path(song_pair) %>
+                <%= link_to "削除", admin_song_pair_path(song_pair), data: { turbo_method: :delete, turbo_confirm: "削除しますか？" } %>
+              </td>
+              <td><%= song_pair.created_at.strftime('%Y年%m月%d日') %></td>
+              <td><%= song_pair.updated_at.strftime('%Y年%m月%d日') %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/song_pairs/index.html.erb
+++ b/app/views/admin/song_pairs/index.html.erb
@@ -1,3 +1,4 @@
+<% breadcrumb :admin_song_pairs %>
 <%= render 'admin/shared/content_header', header_title: "似てる曲組み合わせ" %>
 <div class="app-content">
   <div class="container-fluid">

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -31,7 +31,6 @@
               <%= link_to current_user.email, "#", class: "nav-link dropdown-toggle", data: { bs_toggle: "dropdown" } %>
               <div class="dropdown-menu dropdown-menu-right" aria-labelledby="userMenu">
                 <%= link_to "musim", root_path, class: "dropdown-item" %>
-                <%= link_to "ログアウト", "#", data: { turbo_method: :delete }, class: "dropdown-item" %>
               </div>
             </li>
           </ul>
@@ -50,27 +49,27 @@
           <nav class="mt-2">
             <ul class="nav sidebar-menu flex-column" data-lte-toggle="treeview" role="menu" data-accordion="false">
               <li class="nav-item">
-                <%= link_to "#", class: "nav-link" do %>
-                  <i class="nav-icon fas fa-list"></i>
-                  <p>こんな具合に</p>
+                <%= link_to admin_song_pairs_path, class: "nav-link" do %>
+                  <i class="nav-icon fas fa-radio"></i>
+                  <p>似てる曲組み合わせ</p>
                 <% end %>
               </li>
               <li class="nav-item">
                 <%= link_to "#", class: "nav-link" do %>
-                  <i class="nav-icon fas fa-pencil-alt"></i>
-                  <p>サイドバーの</p>
+                  <i class="nav-icon fas fa-music"></i>
+                  <p>楽曲</p>
                 <% end %>
               </li>
               <li class="nav-item">
                 <%= link_to "#", class: "nav-link" do %>
-                  <i class="nav-icon fa-regular fa-rectangle-list"></i>
-                  <p>コンテンツを</p>
+                  <i class="nav-icon fas fa-microphone-lines"></i>
+                  <p>アーティスト</p>
                 <% end %>
               </li>
               <li class="nav-item">
                 <%= link_to "#", class: "nav-link" do %>
-                  <i class="nav-icon fa-solid fa-pen-to-square"></i>
-                  <p>表示</p>
+                  <i class="nav-icon fas fa-user"></i>
+                  <p>ユーザー</p>
                 <% end %>
               </li>
             </ul>
@@ -80,6 +79,7 @@
 
       <%# メインコンテンツ %>
       <main class="app-main">
+        <%= render 'shared/flash_message' %>
         <%= yield %>
       </main>
       <script src="https://code.jquery.com/jquery-3.6.0.min.js" crossorigin="anonymous"></script>

--- a/app/views/song_pairs/edit.html.erb
+++ b/app/views/song_pairs/edit.html.erb
@@ -35,7 +35,7 @@
     <p>リリース年: <%= @song_pair.similar_song.release_date %></p>
     <%= render 'shared/media_widget', song: @song_pair.similar_song %>
     <div class="mb-3">
-      <%= f.label :similar_song_description, "曲1の説明", class: "form-label" %>
+      <%= f.label :similar_song_description, "曲2の説明", class: "form-label" %>
       <%= f.text_area :similar_song_description, class: "form-control" %>
       <p>注目して欲しいポイントや似てると思ったポイントを記載してください。<br>例) 01:20辺りのメロディ</p>
     </div>

--- a/app/views/song_pairs/new.html.erb
+++ b/app/views/song_pairs/new.html.erb
@@ -62,14 +62,12 @@
         <div class="mb-3 song-submit-form">
           <%= song1_form.label :title, "曲名", class: "form-label" %>
           <%= song1_form.text_field :title, class: "form-control", data: { autocomplete_target: "input" } %>
-          <%= song1_form.hidden_field :title, data: { autocomplete_target: "hidden" } %>
           <ul class="list-group" data-autocomplete-target="results"></ul>
         </div>
         <%= song1_form.fields_for :artists do |artist1_form| %>
           <div class="mb-3 song-submit-form" data-controller="artist-autocomplete" data-artist-autocomplete-url-value=<%= autocomplete_artists_path %>>
             <%= artist1_form.label :name, "アーティスト名", class: "form-label" %>
             <%= artist1_form.text_field :name, class: "form-control", data: { artist_autocomplete_target: "input", autocomplete_target: "artist" } %>
-            <%= artist1_form.hidden_field :name, data: { artist_autocomplete_target: "hidden" } %>
             <ul data-artist-autocomplete-target="results" class="list-group"></ul>
           </div>
         <% end %>
@@ -107,7 +105,6 @@
           <div class="mb-3 song-submit-form" data-controller="artist-autocomplete" data-artist-autocomplete-url-value=<%= autocomplete_artists_path %>>
             <%= artist2_form.label :name, "アーティスト名", class: "form-label" %>
             <%= artist2_form.text_field :name, class: "form-control", data: { artist_autocomplete_target: "input", autocomplete_target: "artist" } %>
-            <%= artist2_form.hidden_field :name, data: { artist_autocomplete_target: "hidden" } %>
             <ul data-artist-autocomplete-target="results" class="list-group"></ul>
           </div>
         <% end %>

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -1,0 +1,46 @@
+# crumb :root do
+#   link "Home", root_path
+# end
+
+# crumb :projects do
+#   link "Projects", projects_path
+# end
+
+# crumb :project do |project|
+#   link project.name, project_path(project)
+#   parent :projects
+# end
+
+# crumb :project_issues do |project|
+#   link "Issues", project_issues_path(project)
+#   parent :project, project
+# end
+
+# crumb :issue do |issue|
+#   link issue.title, issue_path(issue)
+#   parent :project_issues, issue.project
+# end
+
+# If you want to split your breadcrumbs configuration over multiple files, you
+# can create a folder named `config/breadcrumbs` and put your configuration
+# files there. All *.rb files (e.g. `frontend.rb` or `products.rb`) in that
+# folder are loaded and reloaded automatically when you change them, just like
+# this file (`config/breadcrumbs.rb`).
+
+# 管理者ページ用のパンくずリスト設定
+# ダッシュボードトップ
+crumb :admin_root do
+  link "Dashboard", admin_root_path
+end
+
+# 似てる曲組み合わせ一覧
+crumb :admin_song_pairs do
+  link "似てる曲組み合わせ", admin_song_pairs_path
+  parent :admin_root
+end
+
+# 似てる曲組み合わせ編集
+crumb :edit_admin_song_pair do |song_pair|
+  link "#{song_pair.original_song.title} x #{song_pair.similar_song.title}", song_pair
+  parent :admin_song_pairs
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,7 @@ Rails.application.routes.draw do
   # 管理者関連
   namespace :admin do
     root "dashboards#top"
+    resources :song_pairs, only: %i[index edit update destroy]
   end
 
   # 楽曲関連


### PR DESCRIPTION
# 概要
管理者ページにて`SongPair`の管理用ページと機能の実装

# 詳細
管理者ページの`SongPair`管理機能を以下のように実装
- ダッシュボード内サイドバーの`似てる曲組み合わせ`タブから管理ページに移動可能
- 似てる曲組み合わせ(`SongPair`)の一覧を表示
- 閲覧リンクから該当ページに移動可能
- 編集リンクから該当データの編集ページへ移動
  - カテゴリー、楽曲説明の編集が可能
- 削除リンクから該当データの削除が可能

# その他
- 管理者ページ内にパンくずリストの設置(将来的に一般ページにも実装出来るように汎用性のある`gem "gretel"`により実装)
- 一部ページ内の表記ミスの修正