### PR TITLE
管理者ページの'Song'管理機能の実装

### DIFF
--- a/app/controllers/admin/songs_controller.rb
+++ b/app/controllers/admin/songs_controller.rb
@@ -1,0 +1,39 @@
+module Admin
+  class SongsController < BaseController
+    layout 'admin'
+
+    def index
+      @songs = Song.includes(:song_pairs, :artists)
+    end
+
+    def edit
+      @song = Song.find(params[:id])
+    end
+
+    def update
+      @song = Song.find(params[:id])
+      if @song.update(song_params)
+        redirect_to admin_songs_path, notice: "楽曲情報を更新しました"
+      else
+        flash.now[:alert] = "入力に誤りがあります"
+        render :edit, status: :unprocessable_entity
+      end
+    end
+
+    def destroy
+      @song = Song.find(params[:id])
+      if @song.song_pairs.presence || @song.similar_song_pairs.presence
+        redirect_to admin_songs_path, alert: "該当楽曲が含まれた似てる曲組み合わせが存在します: #{@song.song_pairs_count}件"
+      else
+        @song.destroy
+        redirect_to admin_songs_path, notice: "削除しました"
+      end
+    end
+
+    private
+    
+    def song_params
+      params.require(:song).permit(:title, :release_date, :media_url)
+    end
+  end
+end

--- a/app/models/song.rb
+++ b/app/models/song.rb
@@ -1,5 +1,5 @@
 class Song < ApplicationRecord
-  has_many :song_artists, dependent: :nullify
+  has_many :song_artists, dependent: :destroy
   has_many :artists, through: :song_artists
   has_many :song_pairs, class_name: "SongPair", foreign_key: :original_song_id, inverse_of: :original_song, dependent: :nullify
   has_many :similar_song_pairs, class_name: "SongPair", foreign_key: :similar_song_id, inverse_of: :similar_song, dependent: :nullify
@@ -44,6 +44,10 @@ class Song < ApplicationRecord
   # 該当する曲の含まれる似てる曲・サンプリング曲の組み合わせ(SongPair)を取得
   def song_pair(song)
     song_pairs.find_by(similar_song_id: song.id).presence || similar_song_pairs.find_by(original_song_id: song.id)
+  end
+
+  def song_pairs_count
+    song_pairs.count + similar_song_pairs.count
   end
 
   # ransackでの検索対象カラムを設定

--- a/app/views/admin/songs/edit.html.erb
+++ b/app/views/admin/songs/edit.html.erb
@@ -1,0 +1,51 @@
+<% breadcrumb :edit_admin_song, @song %>
+<%= render 'admin/shared/content_header', header_title: "楽曲情報の編集" %>
+<div class="app-content">
+  <div class="container-fluid">
+    <div class="row">
+      <%= form_with model: @song, url: admin_song_path(@song), local: true, data: { turbo: false } do |f| %>
+        <% if @song.errors.any? %>
+          <div id="error_explanation" class="alert alert-danger">
+            <ul>
+              <% @song.errors.each do |error| %>
+                <li><%= error.full_message %></li>
+              <% end %>
+            </ul>
+          </div>
+        <% end %>
+        <table class="table table-bordered">
+          <thead>
+            <tr>
+              <th></th>
+              <th>楽曲情報</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><%= f.label :title %></td>
+              <td><%= f.text_field :title, class: "form-control" %></td>
+            </tr>
+            <tr>
+              <td>アーティスト名</td>
+              <td><%= @song.artist_list %></td>
+            </tr>
+            <tr>
+              <td><%= f.label :release_date %></td>
+              <td><%= f.select :release_date, options_for_select((1870..Date.today.year).to_a.reverse.map(&:to_s), f.object.release_date), {}, class: "form-select", data: { field: 'year' } %></td>
+            </tr>
+            <tr>
+              <td><%= f.label :media_url %></td>
+              <td>
+                <div id="media_player_1"></div>
+                <%= f.text_field :media_url, id: "media_url_1", class: "form-control" %>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        <div class="d-flex justify-content-center mb-4">
+          <%= f.submit "編集を完了", class: "btn btn-primary btn-block mx-3" %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/songs/index.html.erb
+++ b/app/views/admin/songs/index.html.erb
@@ -1,0 +1,38 @@
+<% breadcrumb :admin_songs %>
+<%= render 'admin/shared/content_header', header_title: "楽曲" %>
+<div class="app-content">
+  <div class="container-fluid">
+    <div class="row">
+      <table class="table">
+        <thead>
+          <tr>
+            <th>ID</th>
+            <th>曲名</th>
+            <th>アーティスト名</th>
+            <th>似ている曲組み合わせ数</th>
+            <th></th>
+            <th>登録日時</th>
+            <th>更新日時</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% @songs.each do |song| %>
+            <tr>
+              <td><%= song.id %></td>
+              <td><%= song.title %></td>
+              <td><%= song.artist_list %></td>
+              <td><%= song.song_pairs_count %></td>
+              <td>
+                <%= link_to "閲覧", song_path(song) %>
+                <%= link_to "編集", edit_admin_song_path(song) %>
+                <%= link_to "削除", admin_song_path(song), data: { turbo_method: :delete, turbo_confirm: "削除しますか？" } %>
+              </td>
+              <td><%= song.created_at.strftime('%Y年%m月%d日') %></td>
+              <td><%= song.updated_at.strftime('%Y年%m月%d日') %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -55,7 +55,7 @@
                 <% end %>
               </li>
               <li class="nav-item">
-                <%= link_to "#", class: "nav-link" do %>
+                <%= link_to admin_songs_path, class: "nav-link" do %>
                   <i class="nav-icon fas fa-music"></i>
                   <p>楽曲</p>
                 <% end %>

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -44,3 +44,13 @@ crumb :edit_admin_song_pair do |song_pair|
   link "#{song_pair.original_song.title} x #{song_pair.similar_song.title}", song_pair
   parent :admin_song_pairs
 end
+
+crumb :admin_songs do
+  link "楽曲", admin_songs_path
+  parent :admin_root
+end
+
+crumb :edit_admin_song do |song|
+  link "#{song.artist_list} - #{song.title}"
+  parent :admin_songs
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,7 @@ Rails.application.routes.draw do
   namespace :admin do
     root "dashboards#top"
     resources :song_pairs, only: %i[index edit update destroy]
+    resources :songs, only: %i[index edit update destroy]
   end
 
   # 楽曲関連


### PR DESCRIPTION
# 概要
管理者ページより'Song'の管理できる機能を実装

# 詳細
管理者用のページから`Song`を管理出来る機能を以下のように実装
- ダッシュボード内サイドバーの`楽曲`項目から一覧ページに移動可能
- 閲覧リンクから該当楽曲のページに移動可能
- 編集リンクから該当楽曲の情報を編集可能
  - 曲名、リリース年、メディアURLを編集可能
- 削除リンクから該当楽曲の削除が可能
  - 既存の`SongPair`と紐づいている楽曲は消せないように設定
  - 削除しても関連する`Artist`は消えないように設定
  - 関連する`SongArtist`(アーティストとの紐づけ情報)は消えるように設定