### PR TITLE
管理ページの`Artist`管理機能の実装

### DIFF
--- a/app/controllers/admin/artists_controller.rb
+++ b/app/controllers/admin/artists_controller.rb
@@ -1,0 +1,39 @@
+module Admin
+  class ArtistsController < BaseController
+    layout 'admin'
+
+    def index
+      @artists = Artist.includes(:songs)
+    end
+
+    def edit
+      @artist = Artist.find(params[:id])
+    end
+
+    def update
+      @artist = Artist.find(params[:id])
+      if @artist.update(artist_params)
+        redirect_to admin_artists_path, notice: "アーティスト情報を更新しました"
+      else
+        flash.now[:alert] = "入力に誤りがあります"
+        render :edit, status: :unprocessable_entity
+      end
+    end
+
+    def destroy
+      @artist = Artist.find(params[:id])
+      if @artist.songs.presence || @artist.song_pairs.presence
+        redirect_to admin_artists_path, alert: "該当アーティストが含まれた似てる曲組み合わせや楽曲が存在します"
+      else
+        @artist.destroy
+        redirect_to admin_artists_path, notice: "削除しました"
+      end
+    end
+
+    private
+
+    def artist_params
+      params.require(:artist).permit(:name)
+    end
+  end
+end

--- a/app/controllers/admin/songs_controller.rb
+++ b/app/controllers/admin/songs_controller.rb
@@ -31,7 +31,7 @@ module Admin
     end
 
     private
-    
+
     def song_params
       params.require(:song).permit(:title, :release_date, :media_url)
     end

--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -1,6 +1,19 @@
 class Artist < ApplicationRecord
   has_many :song_artists, dependent: :nullify
-  has_many :song, through: :song_artists
+  has_many :songs, through: :song_artists
 
   validates :name, presence: true, length: { maximum: 255 }
+
+  # 該当アーティストの含まれるSongPairの数を取得
+  def song_pairs
+    result = []
+    songs.each do |song|
+      # データの取得
+      pairs = song.song_pairs + song.similar_song_pairs
+
+      # 同じアーティストの楽曲の組み合わせがあった場合は重複しないように1つとしてカウント
+      result += pairs
+    end
+    result.uniq
+  end
 end

--- a/app/models/song.rb
+++ b/app/models/song.rb
@@ -46,6 +46,7 @@ class Song < ApplicationRecord
     song_pairs.find_by(similar_song_id: song.id).presence || similar_song_pairs.find_by(original_song_id: song.id)
   end
 
+  # 該当する曲の含まれる似てる曲・サンプリング曲の組み合わせ数を取得
   def song_pairs_count
     song_pairs.count + similar_song_pairs.count
   end

--- a/app/views/admin/artists/edit.html.erb
+++ b/app/views/admin/artists/edit.html.erb
@@ -1,0 +1,36 @@
+<% breadcrumb :edit_admin_artist, @artist %>
+<%= render 'admin/shared/content_header', header_title: "アーティスト情報の編集" %>
+<div class="app-content">
+  <div class="container-fluid">
+    <div class="row">
+      <%= form_with model: @artist, url: admin_artist_path(@artist), local: true do |f| %>
+        <% if @artist.errors.any? %>
+          <div id="error_explanation" class="alert alert-danger">
+            <ul>
+              <% @artist.errors.each do |error| %>
+                <li><%= error.full_message %></li>
+              <% end %>
+            </ul>
+          </div>
+        <% end %>
+        <table class="table table-bordered">
+          <thead>
+            <tr>
+              <th></th>
+              <th>アーティスト情報</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><%= f.label :name %></td>
+              <td><%= f.text_field :name, class: "form-control" %></td>
+            </tr>
+          </tbody>
+        </table>
+        <div class="d-flex justify-content-center mb-4">
+          <%= f.submit "編集を完了", class: "btn btn-primary btn-block mx-3" %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/artists/index.html.erb
+++ b/app/views/admin/artists/index.html.erb
@@ -1,0 +1,38 @@
+<% breadcrumb :admin_artists %>
+<%= render 'admin/shared/content_header', header_title: "アーティスト" %>
+<div class="app-content">
+  <div class="container-fluid">
+    <div class="row">
+      <table class="table">
+        <thead>
+          <tr>
+            <th>ID</th>
+            <th>アーティスト名</th>
+            <th>楽曲数</th>
+            <th>似ている曲組み合わせ数</th>
+            <th></th>
+            <th>登録日時</th>
+            <th>更新日時</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% @artists.each do |artist| %>
+            <tr>
+              <td><%= artist.id %></td>
+              <td><%= artist.name %></td>
+              <td><%= artist.songs.count %></td>
+              <td><%= artist.song_pairs.count %></td>
+              <td>
+                <%# link_to "閲覧", artist_path(artist) %>
+                <%= link_to "編集", edit_admin_artist_path(artist) %>
+                <%= link_to "削除", admin_artist_path(artist), data: { turbo_method: :delete, turbo_confirm: "削除しますか？" } %>
+              </td>
+              <td><%= artist.created_at.strftime('%Y年%m月%d日') %></td>
+              <td><%= artist.updated_at.strftime('%Y年%m月%d日') %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -61,7 +61,7 @@
                 <% end %>
               </li>
               <li class="nav-item">
-                <%= link_to "#", class: "nav-link" do %>
+                <%= link_to admin_artists_path, class: "nav-link" do %>
                   <i class="nav-icon fas fa-microphone-lines"></i>
                   <p>アーティスト</p>
                 <% end %>

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -1,32 +1,3 @@
-# crumb :root do
-#   link "Home", root_path
-# end
-
-# crumb :projects do
-#   link "Projects", projects_path
-# end
-
-# crumb :project do |project|
-#   link project.name, project_path(project)
-#   parent :projects
-# end
-
-# crumb :project_issues do |project|
-#   link "Issues", project_issues_path(project)
-#   parent :project, project
-# end
-
-# crumb :issue do |issue|
-#   link issue.title, issue_path(issue)
-#   parent :project_issues, issue.project
-# end
-
-# If you want to split your breadcrumbs configuration over multiple files, you
-# can create a folder named `config/breadcrumbs` and put your configuration
-# files there. All *.rb files (e.g. `frontend.rb` or `products.rb`) in that
-# folder are loaded and reloaded automatically when you change them, just like
-# this file (`config/breadcrumbs.rb`).
-
 # 管理者ページ用のパンくずリスト設定
 # ダッシュボードトップ
 crumb :admin_root do
@@ -45,12 +16,26 @@ crumb :edit_admin_song_pair do |song_pair|
   parent :admin_song_pairs
 end
 
+# 楽曲一覧
 crumb :admin_songs do
   link "楽曲", admin_songs_path
   parent :admin_root
 end
 
+# 楽曲編集
 crumb :edit_admin_song do |song|
   link "#{song.artist_list} - #{song.title}"
   parent :admin_songs
+end
+
+# アーティスト一覧
+crumb :admin_artists do
+  link "アーティスト", admin_artists_path
+  parent :admin_root
+end
+
+# アーティスト編集
+crumb :edit_admin_artist do |artist|
+  link artist.name
+  parent :admin_artists
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,7 @@ Rails.application.routes.draw do
     root "dashboards#top"
     resources :song_pairs, only: %i[index edit update destroy]
     resources :songs, only: %i[index edit update destroy]
+    resources :artists, only: %i[index edit update destroy]
   end
 
   # 楽曲関連


### PR DESCRIPTION
# 概要
管理ページにて`Artist`を管理出来る機能の実装

# 詳細
管理ページより`Artist`を管理する機能を以下のように実装
- 管理ページのサイドバー内`アーティスト`項目からアーティスト管理ページに移動可能
- 編集リンクよりアーティスト名の変更が可能
  - 該当するアーティストが紐づけられた楽曲や似ている曲組み合わせが存在する場合は削除できないように設定
- 削除リンクよりデータの削除が可能