### PR TITLE
管理ページの`User`管理機能の実装

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,0 +1,15 @@
+module Admin
+  class UsersController < BaseController
+    layout 'admin'
+
+    def index
+      @users = User.includes(:song_pairs)
+    end
+
+    def destroy
+      @user = User.find(params[:id])
+      @user.destroy
+      redirect_to admin_users_path, notice: "削除しました"
+    end
+  end
+end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -6,10 +6,35 @@ module Admin
       @users = User.includes(:song_pairs)
     end
 
+    def song_pairs
+      @user = User.find(params[:id])
+      @song_pairs = @user.song_pairs
+    end
+
+    def edit
+      @user = User.find(params[:id])
+    end
+
+    def update
+      @user = User.find(params[:id])
+      if @user.update(user_params)
+        redirect_to admin_users_path, notice: "ユーザー情報を更新しました"
+      else
+        flash.now[:alert] = "入力に誤りがあります"
+        render :edit, status: :unprocessable_entity
+      end
+    end
+
     def destroy
       @user = User.find(params[:id])
       @user.destroy
       redirect_to admin_users_path, notice: "削除しました"
+    end
+
+    private
+
+    def user_params
+      params.require(:user).permit(:role)
     end
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,7 @@
 class ApplicationController < ActionController::Base
   before_action :require_login
   before_action :set_search
+  before_action :check_login_history, if: -> { logged_in? }
   skip_before_action :track_ahoy_visit
   before_action :prepare_meta_tags
 
@@ -68,5 +69,13 @@ class ApplicationController < ActionController::Base
     else
       song_pairs.order(created_at: :desc)
     end
+  end
+
+  # ログイン履歴が存在していない場合に記録
+  def check_login_history
+    # ログイン履歴が存在している場合は処理をスキップ
+    return if current_user.last_login_at.presence
+
+    current_user.update(last_login_at: Time.current)
   end
 end

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -7,6 +7,7 @@ class UserSessionsController < ApplicationController
   def create
     @user = login(params[:email], params[:password])
     if @user
+      @user.update(last_login_at: Time.current)
       redirect_to root_path, notice: 'ログインしました'
     else
       flash.now[:alert] = 'メールアドレスまたはパスワードが正しくありません'

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -1,0 +1,44 @@
+<% breadcrumb :edit_admin_user, @user %>
+<%= render 'admin/shared/content_header', header_title: "ユーザー情報の編集" %>
+<div class="app-content">
+  <div class="container-fluid">
+    <div class="row">
+      <%= form_with model: @user, url: admin_user_path(@user), local: true do |f| %>
+        <% if @user.errors.any? %>
+          <div id="error_explanation" class="alert alert-danger">
+            <ul>
+              <% @user.errors.each do |error| %>
+                <li><%= error.full_message %></li>
+              <% end %>
+            </ul>
+          </div>
+        <% end %>
+        <table class="table table-bordered">
+          <thead>
+            <tr>
+              <th></th>
+              <th>ユーザー情報</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>ユーザー名</td>
+              <td><%= @user.name %></td>
+            </tr>
+            <tr>
+              <td>メールアドレス</td>
+              <td><%= @user.email %></td>
+            </tr>
+            <tr>
+              <td><%= f.label :role %></td>
+              <td><%= f.select :role, User.roles.keys.map { |role| [role.humanize, role] }, {}, class: 'form-select' %></td>
+            </tr>
+          </tbody>
+        </table>
+        <div class="d-flex justify-content-center mb-4">
+          <%= f.submit "編集を完了", class: "btn btn-primary btn-block mx-3" %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -1,0 +1,46 @@
+<% breadcrumb :admin_users %>
+<%= render 'admin/shared/content_header', header_title: "ユーザー" %>
+<div class="app-content">
+  <div class="container-fluid">
+    <div class="row">
+      <table class="table">
+        <thead>
+          <tr>
+            <th>ID</th>
+            <th>ユーザー名</th>
+            <th>メールアドレス</th>
+            <th>権限</th>
+            <th>似てる曲組み合わせ</th>
+            <th></th>
+            <th>登録日時</th>
+            <th>更新日時</th>
+            <th>最終ログイン</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% @users.each do |user| %>
+            <tr>
+              <td><%= user.id %></td>
+              <td><%= user.name %></td>
+              <td><%= user.email %></td>
+              <td><%= user.role %></td>
+              <td>
+                <%= user.song_pairs.count %>
+                <% if user.song_pairs.presence %>
+                  <%= link_to "一覧", song_pairs_admin_user_path(user) %>
+                <% end %>
+              </td>
+              <td>
+                <%= link_to "編集", edit_admin_user_path(user) %>
+                <%= link_to "削除", admin_user_path(user), data: { turbo_method: :delete, turbo_confirm: "削除しますか？" } %>
+              </td>
+              <td><%= user.created_at.strftime('%Y年%m月%d日') %></td>
+              <td><%= user.updated_at.strftime('%Y年%m月%d日') %></td>
+              <td><%= user.last_login_at.strftime('%Y年%m月%d日') if user.last_login_at.presence %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/users/song_pairs.html.erb
+++ b/app/views/admin/users/song_pairs.html.erb
@@ -1,0 +1,38 @@
+<% breadcrumb :song_pairs_admin_user, @user %>
+<%= render 'admin/shared/content_header', header_title: "登録した似てる曲組み合わせ" %>
+<div class="app-content">
+  <div class="container-fluid">
+    <div class="row">
+      <table class="table">
+        <thead>
+          <tr>
+            <th>ID</th>
+            <th>original_song</th>
+            <th>similar_song</th>
+            <th>カテゴリー</th>
+            <th></th>
+            <th>登録日時</th>
+            <th>更新日時</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% @song_pairs.each do |song_pair| %>
+            <tr>
+              <td><%= song_pair.id %></td>
+              <td><%= song_pair.original_song.artist_list %> / <%= song_pair.original_song.title %></td>
+              <td><%= song_pair.similar_song.artist_list %> / <%= song_pair.similar_song.title %></td>
+              <td><%= song_pair.similarity_category_name %></td>
+              <td>
+                <%= link_to "閲覧", song_pair_path(song_pair) %>
+                <%= link_to "編集", edit_admin_song_pair_path(song_pair) %>
+                <%= link_to "削除", admin_song_pair_path(song_pair), data: { turbo_method: :delete, turbo_confirm: "削除しますか？" } %>
+              </td>
+              <td><%= song_pair.created_at.strftime('%Y年%m月%d日') %></td>
+              <td><%= song_pair.updated_at.strftime('%Y年%m月%d日') %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -67,7 +67,7 @@
                 <% end %>
               </li>
               <li class="nav-item">
-                <%= link_to "#", class: "nav-link" do %>
+                <%= link_to admin_users_path, class: "nav-link" do %>
                   <i class="nav-icon fas fa-user"></i>
                   <p>ユーザー</p>
                 <% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -12,14 +12,8 @@ module SimilarSongs
     config.load_defaults 7.0
     config.i18n.default_locale = :ja
     config.i18n.available_locales = [:en, :ja]
-
-    # Configuration for the application, engines, and railties goes here.
-    #
-    # These settings can be overridden in specific environments using the files
-    # in config/environments, which are processed later.
-    #
-    # config.time_zone = "Central Time (US & Canada)"
-    # config.eager_load_paths << Rails.root.join("extras")
+    config.time_zone = 'Tokyo'
+    config.active_record.default_timezone = :local
 
     config.generators.system_tests = nil
     config.generators do |g|

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -39,3 +39,21 @@ crumb :edit_admin_artist do |artist|
   link artist.name
   parent :admin_artists
 end
+
+# ユーザー一覧
+crumb :admin_users do
+  link "ユーザー", admin_users_path
+  parent :admin_root
+end
+
+# ユーザー編集
+crumb :edit_admin_user do |user|
+  link user.name
+  parent :admin_users
+end
+
+# ユーザーの登録した似てる曲組み合わせ
+crumb :song_pairs_admin_user do |user|
+  link "#{user.name}の登録した似てる曲組み合わせ"
+  parent :admin_users
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,11 +20,15 @@ Rails.application.routes.draw do
 
   # 管理者関連
   namespace :admin do
-    root "dashboards#top"
+    root 'dashboards#top'
     resources :song_pairs, only: %i[index edit update destroy]
     resources :songs, only: %i[index edit update destroy]
     resources :artists, only: %i[index edit update destroy]
-    resources :users, only: %i[index edit update destroy]
+    resources :users, only: %i[index edit update destroy] do
+      member do
+        get 'song_pairs', to: 'users#song_pairs'
+      end
+    end
   end
 
   # 楽曲関連

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,7 @@ Rails.application.routes.draw do
     resources :song_pairs, only: %i[index edit update destroy]
     resources :songs, only: %i[index edit update destroy]
     resources :artists, only: %i[index edit update destroy]
+    resources :users, only: %i[index edit update destroy]
   end
 
   # 楽曲関連

--- a/db/migrate/20241214211921_add_login_history_to_users.rb
+++ b/db/migrate/20241214211921_add_login_history_to_users.rb
@@ -1,0 +1,5 @@
+class AddLoginHistoryToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :last_login_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_12_10_132127) do
+ActiveRecord::Schema[7.0].define(version: 2024_12_14_211921) do
   create_table "ahoy_events", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "visit_id"
     t.bigint "user_id"
@@ -103,6 +103,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_12_10_132127) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "role", default: "general", null: false
+    t.datetime "last_login_at"
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 


### PR DESCRIPTION
# 概要
管理ページにて`User`を管理する機能の実装

# 詳細
管理ページから`User`を管理する機能を以下のように実装
- 管理ページ内サイドバーの`ユーザー`から管理ページ及び一覧ページに移動可能
- 似てる曲組み合わせ項目の一覧リンクから該当ユーザーの登録した`SongPair`の一覧を表示するページに移動可能
- 編集リンクから編集ページに移動可能
  - ユーザーの権限を変更可能
- 削除リンクからユーザーの削除が可能