### PR TITLE
メールアドレス変更機能の実装

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -33,6 +33,10 @@ class UsersController < ApplicationController
     @user = current_user
   end
 
+  def edit_email
+    @user = current_user
+  end
+
   def create
     @user = User.new(user_params)
     if @user.save
@@ -53,7 +57,36 @@ class UsersController < ApplicationController
     end
   end
 
+  def update_email
+    @user = current_user
+    # パスワード認証
+    unless @user.valid_password?(user_email_params[:password])
+      flash.now[:alert] = t("views.flash_message.alert.user.password")
+      render :edit_email, status: :unprocessable_entity
+      return
+    end
+
+    # メールアドレス検証
+    if @user.email == user_email_params[:new_email]
+      flash.now[:alert] = t("views.flash_message.alert.user.change_email")
+      render :edit_email, status: :unprocessable_entity
+      return
+    end
+
+    if @user.update(email: user_email_params[:new_email])
+      redirect_to mypage_path, notice: t("views.flash_message.notice.user.update")
+    else
+      flash.now[:alert] = t("views.flash_message.alert.form_error")
+      render :edit_email, status: :unprocessable_entity
+    end
+
+  end
+
   private
+
+  def user_email_params
+    params.require(:user).permit(:new_email, :password)
+  end
 
   def user_params
     params.require(:user).permit(:name, :email, :password, :password_confirmation)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -79,7 +79,6 @@ class UsersController < ApplicationController
       flash.now[:alert] = t("views.flash_message.alert.form_error")
       render :edit_email, status: :unprocessable_entity
     end
-
   end
 
   private

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -4,6 +4,14 @@
     <%= f.label :name, class: "form-label" %>
     <%= f.text_field :name, class: "form-control" %>
   </div>
+  <div class="mb-3">
+    <label class="form-label"><%= t("activerecord.attributes.user.email") %></label>
+    <p><%= @user.email %> <%= link_to t("views.users.edit.change"), mypage_email_path %></p>
+  </div>
+  <div class="mb-3">
+    <label class="form-label"><%= t("activerecord.attributes.user.password") %></label>
+    <p>*****</p>
+  </div>
   <div class="d-grid mb-3">
     <%= f.submit t("views.users.edit.submit"), class: "btn btn-primary btn-block" %>
   </div>

--- a/app/views/users/edit_email.html.erb
+++ b/app/views/users/edit_email.html.erb
@@ -1,0 +1,18 @@
+<h1 class="text-center mb-4"><%= t("views.users.edit_email.title") %></h1>
+<%= form_with model: @user, url: mypage_email_path, local: true do |f| %>
+  <div class="mb-3">
+    <label class="form-label"><%= t("views.users.edit_email.current_email") %></label>
+    <p><%= @user.email %></p>
+  </div>
+  <div class="mb-3">
+    <%= f.label :new_email, t("views.users.edit_email.new_email"), class: "form-label" %>
+    <%= f.email_field :new_email, class: "form-control", placeholder: t("views.users.new.email.placeholder") %>
+  </div>
+  <div class="mb-3">
+    <%= f.label :password, class: "form-label" %>
+    <%= f.password_field :password, class: "form-control" %>
+  </div>
+  <div class="d-grid mb-3">
+    <%= f.submit t("views.users.edit.submit"), class: "btn btn-primary btn-block" %>
+  </div>
+<% end %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -166,6 +166,11 @@ ja:
       edit:
         title: "ユーザー情報の編集"
         submit: "更新"
+        change: "変更"
+      edit_email:
+        title: "メールアドレスの変更"
+        current_email: "現在のメールアドレス"
+        new_email: "新しいメールアドレス"
       mypage:
         title: "マイページ"
         user:
@@ -205,6 +210,9 @@ ja:
       submit: "検索"
     flash_message:
       alert:
+        user:
+          password:
+          change_email:
         user_sessions: "メールアドレスまたはパスワードが正しくありません"
         edit_permit_error: "編集権限がありません"
         form_error: "入力に誤りがあります"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,8 @@ Rails.application.routes.draw do
   get 'mypage/submit_songs', to: 'users#submit_songs', as: :submit_songs
   get 'mypage/evaluated_songs', to: 'users#evaluated_songs', as: :evaluated_songs
   get 'mypage/edit', to: 'users#edit', as: :edit_mypage
+  get 'mypage/email', to: 'users#edit_email', as: :edit_email
+  patch 'mypage/email', to: "users#update_email"
   patch 'mypage', to: 'users#update'
   get 'signup', to: 'users#new'
   post 'signup', to: 'users#create'


### PR DESCRIPTION
# 概要
ユーザーのメールアドレス変更機能の実装

# 詳細
ユーザーのメールアドレスを変更できる機能を以下のように実装
- マイページの`ユーザー情報の編集`ページからメールアドレス項目の変更リンクよりメールアドレス変更ページに移動可能
- 新しいメールアドレスが現在のメールアドレスと同じ場合はエラーを出力
- 更新時にはパスワードの入力も要求するように設定
- i18nによるローカライズ済み