### PR TITLE
忘れた人向けのパスワード再設定機能の実装

### DIFF
--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -1,0 +1,40 @@
+class PasswordResetsController < ApplicationController
+  skip_before_action :require_login
+  before_action :redirect_if_logged_in
+
+  def new; end
+
+  def create
+    if params[:email].empty?
+      flash.now[:alert] = t("views.flash_message.alert.password_resets.email")
+      render :new, status: :unprocessable_entity
+    else
+      @user = User.find_by(email: params[:email])
+      @user&.deliver_reset_password_instructions!
+      redirect_to login_path, notice: t("views.flash_message.notice.password_resets.create")
+    end
+  end
+
+  def edit
+    @user = User.load_from_reset_password_token(params[:id])
+    not_authenticated unless @user
+  end
+
+  def update
+    @user = User.load_from_reset_password_token(params[:id])
+    not_authenticated unless @user
+
+    if @user.update(password_params) && password_params[:password].presence
+      redirect_to login_path, notice: t("views.flash_message.notice.password_resets.update")
+    else
+      flash.now[:alert] = t("views.flash_message.alert.form_error")
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def password_params
+    params.require(:user).permit(:password, :password_confirmation)
+  end
+end

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -4,6 +4,11 @@ class PasswordResetsController < ApplicationController
 
   def new; end
 
+  def edit
+    @user = User.load_from_reset_password_token(params[:id])
+    not_authenticated unless @user
+  end
+
   def create
     if params[:email].empty?
       flash.now[:alert] = t("views.flash_message.alert.password_resets.email")
@@ -13,11 +18,6 @@ class PasswordResetsController < ApplicationController
       @user&.deliver_reset_password_instructions!
       redirect_to login_path, notice: t("views.flash_message.notice.password_resets.create")
     end
-  end
-
-  def edit
-    @user = User.load_from_reset_password_token(params[:id])
-    not_authenticated unless @user
   end
 
   def update

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -3,6 +3,6 @@ class UserMailer < ApplicationMailer
     @user = user
     @url = edit_password_reset_url(@user.reset_password_token)
 
-    mail(to: @user.email, subject: "パスワードのリセット")
+    mail(to: @user.email, subject: t("mailer.user.reset_password_email.subject"))
   end
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,0 +1,8 @@
+class UserMailer < ApplicationMailer
+  def reset_password_email(user)
+    @user = user
+    @url = edit_password_reset_url(@user.reset_password_token)
+
+    mail(to: @user.email, subject: "パスワードのリセット")
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,6 +10,7 @@ class User < ApplicationRecord
   validates :password, length: { minimum: 6 }, if: -> { new_record? || changes[:crypted_password] }
   validates :password, confirmation: true, if: -> { new_record? || changes[:crypted_password] }
   validates :password_confirmation, presence: true, if: -> { new_record? || changes[:crypted_password] }
+  validates :reset_password_token, presence: true, uniqueness: true, allow_nill: true
 
   enum :role, { general: 'general', admin: 'admin' }
   validates :role, inclusion: { in: roles.keys }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,9 +8,9 @@ class User < ApplicationRecord
   validates :name, presence: true, length: { minimum: 3, maximum: 255 }
   validates :email, presence: true, uniqueness: true
   validates :password, length: { minimum: 6 }, if: -> { new_record? || changes[:crypted_password] }
-  validates :password, confirmation: true, if: -> { new_record? || changes[:crypted_password] }
+  validates :password, presence: true, confirmation: true, if: -> { new_record? || changes[:crypted_password] }
   validates :password_confirmation, presence: true, if: -> { new_record? || changes[:crypted_password] }
-  validates :reset_password_token, presence: true, uniqueness: true, allow_nill: true
+  validates :reset_password_token, presence: true, uniqueness: true, allow_nil: true
 
   enum :role, { general: 'general', admin: 'admin' }
   validates :role, inclusion: { in: roles.keys }

--- a/app/views/password_resets/edit.html.erb
+++ b/app/views/password_resets/edit.html.erb
@@ -1,0 +1,14 @@
+<h1 class="text-center mb-4"><%= t("views.password_resets.edit.title") %></h1>
+<%= form_with model: @user, url: password_reset_path(params[:id]), local: true do |f| %>
+  <div class="mb-3">
+    <%= f.label :password, t("views.password_resets.edit.password"), class: "form-label" %>
+    <%= f.password_field :password, class: "form-control" %>
+  </div>
+  <div class="mb-3">
+    <%= f.label :password_confirmation, class: "form-label" %>
+    <%= f.password_field :password_confirmation, class: "form-control" %>
+  </div>
+  <div class="d-grid mb-3">
+    <%= f.submit t("views.password_resets.edit.submit"), class: "btn btn-primary btn-block" %>
+  </div>
+<% end %>

--- a/app/views/password_resets/new.html.erb
+++ b/app/views/password_resets/new.html.erb
@@ -1,0 +1,21 @@
+<h1 class="text-center mb-4"><%= t("views.password_resets.new.title") %></h1>
+<%= form_with url: password_resets_path, local: true do |f| %>
+  <div class="mb-3 text-center">
+    <p>
+      <% t("views.password_resets.new.content").each do |content| %>
+        <%= content %><br>
+      <% end %>
+    </p>
+  </div>
+  <div class="mb-3">
+    <%= f.label :email, t('views.user_sessions.email.label'), class: "form-label" %>
+    <%= f.email_field :email, class: "form-control", placeholder: t('views.user_sessions.email.placeholder'), autofocus: true %>
+  </div>
+  <div class="d-grid mb-3">
+    <%= f.submit t("views.password_resets.new.submit"), class: "btn btn-primary btn-block" %>
+  </div>
+  <div class="mb-3 text-center">
+    <%= link_to t("views.password_resets.new.login"), login_path %>
+    <%= link_to t('views.user_sessions.signup'), signup_path %>
+  </div>
+<% end %>

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -20,13 +20,11 @@
       </div>
     </div>
   </div>
-  <% unless request.path == login_path || request.path == signup_path %>
-    <div class="header-image text-white">
-      <div class="main-area d-flex flex-column align-items-center">
-        <h1><%= t("views.header.heading") %></h1>
-        <%=link_to t("views.header.signup_to_start"), login_path %>
-        <%= render "shared/search_form" %>
-      </div>
+  <div class="header-image text-white">
+    <div class="main-area d-flex flex-column align-items-center">
+      <h1><%= t("views.header.heading") %></h1>
+      <%=link_to t("views.header.signup_to_start"), login_path %>
+      <%= render "shared/search_form" %>
     </div>
-  <% end %>
+  </div>
 </header>

--- a/app/views/user_mailer/reset_password_email.html.erb
+++ b/app/views/user_mailer/reset_password_email.html.erb
@@ -1,0 +1,5 @@
+<h1>User#reset_password_email</h1>
+
+<p>
+  <%= @greeting %>, find me in app/views/user_mailer/reset_password_email.html.erb
+</p>

--- a/app/views/user_mailer/reset_password_email.html.erb
+++ b/app/views/user_mailer/reset_password_email.html.erb
@@ -1,5 +1,3 @@
-<h1>User#reset_password_email</h1>
-
-<p>
-  <%= @greeting %>, find me in app/views/user_mailer/reset_password_email.html.erb
-</p>
+<p><%= @user.name %> 様</p>
+<p>パスワードの再設定リンクになります。こちらより再設定を行ってください。</p>
+<p><a href="<%= @url %>"><%= @url %></a></p>

--- a/app/views/user_mailer/reset_password_email.text.erb
+++ b/app/views/user_mailer/reset_password_email.text.erb
@@ -1,0 +1,3 @@
+User#reset_password_email
+
+<%= @greeting %>, find me in app/views/user_mailer/reset_password_email.text.erb

--- a/app/views/user_mailer/reset_password_email.text.erb
+++ b/app/views/user_mailer/reset_password_email.text.erb
@@ -1,3 +1,3 @@
-User#reset_password_email
-
-<%= @greeting %>, find me in app/views/user_mailer/reset_password_email.text.erb
+<%= @user.name %> 様
+パスワードの再設定リンクになります。こちらより再設定を行ってください。
+<%= @url %>

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -12,6 +12,7 @@
     <%= f.submit t('views.user_sessions.submit'), class: "btn btn-primary btn-block" %>
   </div>
   <div class="mb-3 text-center">
+    <%= link_to t('views.user_sessions.forget_password'), new_password_reset_path %>
     <%= link_to t('views.user_sessions.signup'), signup_path %>
   </div>
 <% end %>

--- a/config/initializers/sorcery.rb
+++ b/config/initializers/sorcery.rb
@@ -4,7 +4,7 @@
 # Available submodules are: :user_activation, :http_basic_auth, :remember_me,
 # :reset_password, :session_timeout, :brute_force_protection, :activity_logging,
 # :magic_login, :external
-Rails.application.config.sorcery.submodules = []
+Rails.application.config.sorcery.submodules = [:reset_password]
 
 # Here you can configure each submodule's features.
 Rails.application.config.sorcery.configure do |config|
@@ -559,6 +559,7 @@ Rails.application.config.sorcery.configure do |config|
     # Default: `:uid`
     #
     # user.provider_uid_attribute_name =
+    user.reset_password_mailer = UserMailer
   end
 
   # This line must come after the 'user config' block.

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -147,6 +147,7 @@ ja:
         placeholder: "パスワードを入力"
       submit: "ログイン"
       signup: "アカウントを作成する"
+      forget_password: "パスワードを忘れた"
     users:
       new:
         title: "アカウントを作成"
@@ -182,6 +183,18 @@ ja:
         title: "登録した曲"
       evaluated_songs:
         title: "評価した曲"
+    password_resets:
+      new:
+        title: "パスワードを忘れた"
+        content:
+          - "アカウントに登録したメールアドレスを入力してください。"
+          - "パスワード再設定用のリンクが記載されたメールを送信します。"
+        submit: 再設定用のメールを送信
+        login: "ログインする"
+      edit:
+        title: "パスワードを再設定"
+        password: "新しいパスワード"
+        submit: "パスワードの再設定"
     header:
       nav:
         song_submit: "楽曲を登録"
@@ -217,6 +230,8 @@ ja:
         edit_permit_error: "編集権限がありません"
         form_error: "入力に誤りがあります"
         contacts: "入力に誤りがあります"
+        password_resets:
+          email: "メールアドレスを入力してください"
       notice:
         user:
           submit: "ユーザー登録が完了しました"
@@ -229,6 +244,9 @@ ja:
           update: "楽曲情報を更新しました"
           destroy: "楽曲情報を削除しました"
         contacts: "お問い合わせを送信しました"
+        password_resets:
+          create: "パスワード再設定用のメールを送信しました"
+          update: "パスワードをリセットしました"
     static_pages:
       rule:
         title: "利用ルール"
@@ -256,6 +274,9 @@ ja:
         subject: "お問い合わせ内容の確認"
       notification_email:
         subject: "新しいお問い合わせがありました"
+    user:
+      reset_password_email:
+        subject: "パスワードのリセット"
   similarity_category:
     melody: "メロディー"
     style: "ジャンル・スタイル"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,7 @@ Rails.application.routes.draw do
   get 'login', to: 'user_sessions#new'
   post 'login', to: 'user_sessions#create'
   delete 'logout', to: 'user_sessions#destroy'
+  resources :password_resets, only: %i[new create edit update]
 
   # 管理者関連
   namespace :admin do

--- a/db/migrate/20241218003341_sorcery_reset_password.rb
+++ b/db/migrate/20241218003341_sorcery_reset_password.rb
@@ -1,0 +1,10 @@
+class SorceryResetPassword < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :reset_password_token, :string, default: nil
+    add_column :users, :reset_password_token_expires_at, :datetime, default: nil
+    add_column :users, :reset_password_email_sent_at, :datetime, default: nil
+    add_column :users, :access_count_to_reset_password_page, :integer, default: 0
+
+    add_index :users, :reset_password_token
+  end
+end

--- a/db/migrate/20241218031233_remove_index_from_reset_password_token.rb
+++ b/db/migrate/20241218031233_remove_index_from_reset_password_token.rb
@@ -1,0 +1,5 @@
+class RemoveIndexFromResetPasswordToken < ActiveRecord::Migration[7.0]
+  def change
+    remove_index :users, name: "index_users_on_reset_password_token"
+  end
+end

--- a/db/migrate/20241218031314_add_unique_index_to_reset_password_token.rb
+++ b/db/migrate/20241218031314_add_unique_index_to_reset_password_token.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexToResetPasswordToken < ActiveRecord::Migration[7.0]
+  def change
+    add_index :users, :reset_password_token, unique: true, name: "index_users_on_reset_password_token"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_12_15_221305) do
+ActiveRecord::Schema[7.0].define(version: 2024_12_18_003341) do
   create_table "ahoy_events", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "visit_id"
     t.bigint "user_id"
@@ -113,7 +113,12 @@ ActiveRecord::Schema[7.0].define(version: 2024_12_15_221305) do
     t.datetime "updated_at", null: false
     t.string "role", default: "general", null: false
     t.datetime "last_login_at"
+    t.string "reset_password_token"
+    t.datetime "reset_password_token_expires_at"
+    t.datetime "reset_password_email_sent_at"
+    t.integer "access_count_to_reset_password_page", default: 0
     t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["reset_password_token"], name: "index_users_on_reset_password_token"
   end
 
   add_foreign_key "contacts", "users"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_12_18_003341) do
+ActiveRecord::Schema[7.0].define(version: 2024_12_18_031314) do
   create_table "ahoy_events", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "visit_id"
     t.bigint "user_id"
@@ -118,7 +118,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_12_18_003341) do
     t.datetime "reset_password_email_sent_at"
     t.integer "access_count_to_reset_password_page", default: 0
     t.index ["email"], name: "index_users_on_email", unique: true
-    t.index ["reset_password_token"], name: "index_users_on_reset_password_token"
+    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
   add_foreign_key "contacts", "users"


### PR DESCRIPTION
# 概要
ユーザーがパスワードを忘れた際のパスワード再設定機能を実装

# 詳細
パスワード再設定機能を以下のように実装
- ログインページに忘れた人向けのリンクを配置
- 登録時に使用したメールアドレスを入力してもらい、再設定用メールを送信するように設定
- メール内に記載された再設定用ページのURLから再設定用ページに移動可能
- 再設定用ページにて新しいパスワード、再入力を行い再設定を実行