### PR TITLE
パスワード変更機能の実装

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -37,6 +37,10 @@ class UsersController < ApplicationController
     @user = current_user
   end
 
+  def edit_password
+    @user = current_user
+  end
+
   def create
     @user = User.new(user_params)
     if @user.save
@@ -81,10 +85,31 @@ class UsersController < ApplicationController
     end
   end
 
+  def update_password
+    @user = current_user
+    unless @user.valid_password?(user_password_params[:current_password])
+      flash.now[:alert] = t("views.flash_message.alert.user.change_password")
+      render :edit_password, status: :unprocessable_entity
+      return
+    end
+
+    @user.password_confirmation = user_password_params[:password_confirmation]
+    if user_password_params[:password].presence && @user.change_password(user_password_params[:password])
+      redirect_to mypage_path, notice: t("views.flash_message.notice.user.update")
+    else
+      flash.now[:alert] = t("views.flash_message.alert.form_error")
+      render :edit_password, status: :unprocessable_entity
+    end
+  end
+
   private
 
   def user_email_params
     params.require(:user).permit(:new_email, :password)
+  end
+
+  def user_password_params
+    params.require(:user).permit(:current_password, :password, :password_confirmation)
   end
 
   def user_params

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -10,7 +10,7 @@
   </div>
   <div class="mb-3">
     <label class="form-label"><%= t("activerecord.attributes.user.password") %></label>
-    <p>*****</p>
+    <p>***** <%= link_to t("views.users.edit.change"), mypage_password_path %></p>
   </div>
   <div class="d-grid mb-3">
     <%= f.submit t("views.users.edit.submit"), class: "btn btn-primary btn-block" %>

--- a/app/views/users/edit_password.html.erb
+++ b/app/views/users/edit_password.html.erb
@@ -1,0 +1,18 @@
+<h1 class="text-center mb-4"><%= t("views.users.edit_password.title") %></h1>
+<%= form_with model: @user, url: mypage_password_path, local: true do |f| %>
+  <div class="mb-3">
+    <%= f.label :current_password, t("views.users.edit_password.current_password"), class: "form-label" %>
+    <%= f.password_field :current_password, class: "form-control" %>
+  </div>
+  <div class="mb-3">
+    <%= f.label :password, t("views.users.edit_password.password"), class: "form-label" %>
+    <%= f.password_field :password, class: "form-control" %>
+  </div>
+  <div class="mb-3">
+    <%= f.label :password_confirmation, t("views.users.edit_password.password_confirmation"), class: "form-label" %>
+    <%= f.password_field :password_confirmation, class: "form-control" %>
+  </div>
+  <div class="d-grid mb-3">
+    <%= f.submit t("views.users.edit.submit"), class: "btn btn-primary btn-block" %>
+  </div>
+<% end %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -172,6 +172,11 @@ ja:
         title: "メールアドレスの変更"
         current_email: "現在のメールアドレス"
         new_email: "新しいメールアドレス"
+      edit_password:
+        title: "パスワードの変更"
+        current_password: "現在のパスワード"
+        password: "新しいパスワード"
+        password_confirmation: "新しいパスワードの再確認"
       mypage:
         title: "マイページ"
         user:
@@ -226,6 +231,7 @@ ja:
         user:
           password: "パスワードに誤りがあります"
           change_email: "新しいメールアドレスが現在のメールアドレスと同じです"
+          change_password: "現在のパスワードが正しくありません"
         user_sessions: "メールアドレスまたはパスワードが正しくありません"
         edit_permit_error: "編集権限がありません"
         form_error: "入力に誤りがあります"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,8 @@ Rails.application.routes.draw do
   get 'mypage/edit', to: 'users#edit', as: :edit_mypage
   get 'mypage/email', to: 'users#edit_email', as: :edit_email
   patch 'mypage/email', to: "users#update_email"
+  get 'mypage/password', to: 'users#edit_password', as: :edit_password
+  patch 'mypage/password', to: 'users#update_password'
   patch 'mypage', to: 'users#update'
   get 'signup', to: 'users#new'
   post 'signup', to: 'users#create'


### PR DESCRIPTION
# 概要
ユーザーのパスワードを変更する機能を実装

# 詳細
ログイン済みユーザーがパスワードを変更することの出来る機能を以下のように実装
- マイページのユーザー情報編集ページからパスワード変更ページへ移動可能
- 現在のパスワード、新しいパスワード、新しいパスワードの再確認フォームを入力項目として設置
- 必要情報が入力されており、現在のパスワードによる認証が正常に行われたらパスワードの変更完了